### PR TITLE
Add default region for aws integration

### DIFF
--- a/server/src/application/integrations/schema.py
+++ b/server/src/application/integrations/schema.py
@@ -30,6 +30,7 @@ class AWSIntegrationConfig(BaseModel):
     aws_account: str = Field(..., frozen=True)
     aws_assumed_role_name: str | None = Field(default=None)
     aws_session_duration: int | None = Field(default=3600)
+    aws_default_region: str | None = Field(default="us-east-1")
     integration_provider: Literal["aws"] = Field(default="aws", frozen=True)
 
     def get_secrets(self) -> list[tuple[str, EncryptedSecretStr]]:

--- a/server/src/application/integrations/service.py
+++ b/server/src/application/integrations/service.py
@@ -140,6 +140,7 @@ class IntegrationService:
         if not existing_integration:
             raise EntityNotFound("Integration not found")
 
+        await self.audit_log_handler.create_log(existing_integration.id, requester.id, body.action)
         match body.action:
             case ModelActions.DISABLE:
                 existing_integration.status = ModelStatus.DISABLED
@@ -151,7 +152,6 @@ class IntegrationService:
             case _:
                 raise ValueError(f"Action {body.action} is not supported")
 
-        await self.audit_log_handler.create_log(existing_integration.id, requester.id, body.action)
         response = IntegrationResponse.model_validate(existing_integration)
         await self.event_sender.send_event(response, body.action)
         return response

--- a/server/src/application/use_cases/create_integration_with_storage/service.py
+++ b/server/src/application/use_cases/create_integration_with_storage/service.py
@@ -59,7 +59,7 @@ class IntegrationWithStorageService:
             if isinstance(integration.configuration, AWSIntegrationConfig):
                 configuration = {
                     "aws_bucket_name": f"infrakitchen-{integration.configuration.aws_account}-bucket",
-                    "aws_region": "us-east-1",
+                    "aws_region": integration.configuration.aws_default_region or "us-east-1",
                     "storage_provider": "aws",
                 }
             elif isinstance(integration.configuration, GCPIntegrationConfig):

--- a/server/tests/application/providers/aws/test_aws_provider.py
+++ b/server/tests/application/providers/aws/test_aws_provider.py
@@ -8,13 +8,14 @@ from application.providers.aws.aws_provider import AwsAuthentication
 from core.errors import CloudWrongCredentials
 
 
-async def get_account_session(self, region_name: str = "us-east-1"):
+async def get_account_session(self):
     self.environment_variables.update(
         {
             "AWS_ACCESS_KEY_ID": self.aws_access_key_id,
             "AWS_SECRET_ACCESS_KEY": self.aws_secret_access_key.get_decrypted_value(),
             "AWS_SESSION_TOKEN": "session",
             "AWS_ACCOUNT": self.aws_account,
+            "AWS_REGION": self.aws_default_region,
         }
     )
 
@@ -43,6 +44,11 @@ class TestIsValid:
         provider = AwsProvider(configuration=configuration)
         await provider.authenticate()
         assert await provider.is_valid() is True
+        assert provider.environment_variables["AWS_ACCESS_KEY_ID"] == "test_key"
+        assert provider.environment_variables["AWS_SECRET_ACCESS_KEY"] == "test_secret"
+        assert provider.environment_variables["AWS_SESSION_TOKEN"] == "session"
+        assert provider.environment_variables["AWS_ACCOUNT"] == "0123456789012"
+        assert provider.environment_variables["AWS_REGION"] == "us-east-1"
 
     @pytest.mark.asyncio
     async def test_is_valid_failure(self, monkeypatch):

--- a/ui/frontend-lib/src/integrations/components/IntegrationProviderForms.tsx
+++ b/ui/frontend-lib/src/integrations/components/IntegrationProviderForms.tsx
@@ -139,6 +139,27 @@ export const renderFieldsForProvider = (
               />
             )}
           />
+          <Controller
+            name="configuration.aws_default_region"
+            control={control}
+            defaultValue=""
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="AWS Default Region"
+                fullWidth
+                margin="normal"
+                error={
+                  !!(errors.configuration as FieldErrors)?.aws_default_region
+                }
+                helperText={
+                  (errors.configuration as any)?.aws_default_region?.message ||
+                  "Default AWS region for resource management (default to us-east-1 if not specified)"
+                }
+                slotProps={{ input: { readOnly: readonly } }}
+              />
+            )}
+          />
           {isCreateMode && (
             <Controller
               name="create_storage"


### PR DESCRIPTION
1. Put AWS_REGION to env variables for shell client if presented in integration, default region is us-east-1
2. Create storage in a region that defined in integration.