### PR TITLE
Tabbed content in URL, Shareable logs

### DIFF
--- a/ui/frontend-lib/src/common/components/TabbedContent.tsx
+++ b/ui/frontend-lib/src/common/components/TabbedContent.tsx
@@ -1,4 +1,6 @@
-import { useState, SyntheticEvent, ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
+
+import { useLocation, useNavigate, useParams } from "react-router";
 
 import { Box, Tab, Tabs } from "@mui/material";
 
@@ -23,6 +25,9 @@ export const TabbedContent = ({
   onChange,
 }: TabbedContentProps) => {
   const { permissions } = usePermissionProvider();
+  const { tab: activeTabFromPath } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const visibleTabs = tabs.filter(
     ({ requiredPermission, permissionAction }) => {
@@ -37,18 +42,44 @@ export const TabbedContent = ({
     },
   );
 
-  const [tab, setTab] = useState(defaultTab ?? visibleTabs[0]?.label);
+  const activeTab = visibleTabs.find(
+    (t) => t.label.toLowerCase() === activeTabFromPath?.toLowerCase(),
+  );
 
-  const handleChange = (_: SyntheticEvent, val: string) => {
-    setTab(val);
-    onChange?.(val);
-  };
+  useEffect(() => {
+    if (!activeTab && visibleTabs.length > 0) {
+      const targetLabel = (
+        visibleTabs.find((t) => t.label === defaultTab) || visibleTabs[0]
+      ).label.toLowerCase();
+
+      const parts = location.pathname.replace(/\/$/, "").split("/");
+      if (activeTabFromPath) parts[parts.length - 1] = targetLabel;
+      else parts.push(targetLabel);
+
+      navigate(parts.join("/") + location.search, { replace: true });
+    }
+  }, [
+    activeTab,
+    activeTabFromPath,
+    visibleTabs,
+    defaultTab,
+    location.pathname,
+    location.search,
+    navigate,
+  ]);
+
+  if (!activeTab) return null;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
       <Tabs
-        value={tab}
-        onChange={handleChange}
+        value={activeTab.label}
+        onChange={(_, v) => {
+          const parts = location.pathname.replace(/\/$/, "").split("/");
+          parts[parts.length - 1] = v.toLowerCase();
+          navigate(parts.join("/") + location.search);
+          onChange?.(v);
+        }}
         variant="scrollable"
         scrollButtons="auto"
       >
@@ -56,8 +87,7 @@ export const TabbedContent = ({
           <Tab key={label} label={label} value={label} />
         ))}
       </Tabs>
-
-      {visibleTabs.find((t) => t.label === tab)?.content}
+      {activeTab.content}
     </Box>
   );
 };

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { useSearchParams } from "react-router";
+
 import ArticleIcon from "@mui/icons-material/Article";
 import {
   Box,
@@ -19,7 +21,6 @@ import {
 } from "@mui/x-data-grid";
 
 import { CommonDialog, useConfig } from "../../../common";
-import { useLocalStorage } from "../../../common/context/UIStateContext";
 import { AuditLogEntity } from "../../../types";
 import { GetReferenceUrlValue } from "../CommonField";
 import { RelativeTime } from "../RelativeTime";
@@ -33,11 +34,6 @@ export interface AuditProps {
 interface AuditFilterPanelProps {
   search: string;
   setSearch: (value: string) => void;
-}
-
-interface DataGridState {
-  sortModel: GridSortModel;
-  paginationModel: GridPaginationModel;
 }
 
 export const AuditFilterPanel = ({
@@ -71,33 +67,32 @@ export const AuditFilterPanel = ({
 
 export const Audit = ({ entityId }: AuditProps) => {
   const { ikApi } = useConfig();
-  const { get, setKey } = useLocalStorage<Record<string, DataGridState>>();
-  const storageKey = "auditTable";
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const actionsWithLogs = useMemo<string[]>(
     () => ["sync", "dryrun", "dryrun_with_temp_state", "execute"],
     [],
   );
 
-  const savedState = get(storageKey);
+  const selectedTraceId = searchParams.get("traceId");
+  const logsOpen = !!selectedTraceId;
 
   const [auditLogs, setAuditLogs] = useState<AuditLogEntity[]>([]);
   const [search, setSearch] = useState<string>("");
-
-  const [logsOpen, setLogsOpen] = useState<boolean>(false);
-  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
 
   const [filterModel, setFilterModel] = useState<GridFilterModel>({
     items: [],
     quickFilterValues: [],
   });
 
-  const [sortModel, setSortModel] = useState<GridSortModel>(
-    savedState?.sortModel || [{ field: "created_at", sort: "desc" }],
-  );
+  const [sortModel, setSortModel] = useState<GridSortModel>([
+    { field: "created_at", sort: "desc" },
+  ]);
 
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>(
-    savedState?.paginationModel || { page: 0, pageSize: 10 },
-  );
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 10,
+  });
 
   useEffect(() => {
     const id = setTimeout(() => {
@@ -109,11 +104,6 @@ export const Audit = ({ entityId }: AuditProps) => {
     }, 150);
     return () => clearTimeout(id);
   }, [search]);
-
-  // Save sort and pagination state to localStorage
-  useEffect(() => {
-    setKey(storageKey, { sortModel, paginationModel });
-  }, [sortModel, paginationModel, storageKey, setKey]);
 
   const handleSortModelChange = (newSortModel: GridSortModel) => {
     setSortModel(newSortModel);
@@ -184,8 +174,9 @@ export const Audit = ({ entityId }: AuditProps) => {
                 startIcon={<ArticleIcon />}
                 onClick={(e) => {
                   e.stopPropagation();
-                  setSelectedTraceId(params.row.id);
-                  setLogsOpen(true);
+                  const newParams = new URLSearchParams(searchParams);
+                  newParams.set("traceId", params.row.id);
+                  setSearchParams(newParams);
                 }}
               >
                 Logs
@@ -195,7 +186,7 @@ export const Audit = ({ entityId }: AuditProps) => {
         ),
       },
     ],
-    [actionsWithLogs],
+    [actionsWithLogs, searchParams, setSearchParams],
   );
 
   return (
@@ -246,7 +237,11 @@ export const Audit = ({ entityId }: AuditProps) => {
                   title="Logs"
                   maxWidth="md"
                   open={logsOpen}
-                  onClose={() => setLogsOpen(false)}
+                  onClose={() => {
+                    const newParams = new URLSearchParams(searchParams);
+                    newParams.delete("traceId");
+                    setSearchParams(newParams);
+                  }}
                   content={
                     <Logs entityId={entityId} traceId={selectedTraceId} />
                   }

--- a/ui/frontend-lib/src/resources/pages/Resource.tsx
+++ b/ui/frontend-lib/src/resources/pages/Resource.tsx
@@ -43,4 +43,4 @@ export const ResourcePage = () => {
   );
 };
 
-ResourcePage.path = "/resources/:resource_id";
+ResourcePage.path = "/resources/:resource_id/:tab?";

--- a/ui/frontend-lib/src/templates/components/TemplateContent.tsx
+++ b/ui/frontend-lib/src/templates/components/TemplateContent.tsx
@@ -1,5 +1,7 @@
 import { Box } from "@mui/material";
 
+import { Audit } from "../../common/components/activity/Audit";
+import { Revision } from "../../common/components/activity/Revision";
 import { DangerZoneCard } from "../../common/components/DangerZoneCard";
 import {
   TabbedContent,
@@ -28,6 +30,20 @@ export const TemplateContent = () => {
           entity_name={entity._entity_name}
         />
       ),
+    },
+    {
+      label: "Audit",
+      content: <Audit entityId={entity.id} />,
+    },
+    {
+      label: "Revisions",
+      content: (
+        <Box sx={{ maxWidth: 1000 }}>
+          <Revision resourceId={entity.id} resourceRevision={0} />
+        </Box>
+      ),
+      requiredPermission: `resource:${entity.id}`,
+      permissionAction: "write",
     },
     {
       label: "Settings",

--- a/ui/frontend-lib/src/templates/pages/Template.tsx
+++ b/ui/frontend-lib/src/templates/pages/Template.tsx
@@ -24,6 +24,7 @@ export const TemplatePage = () => {
     <EntityProvider entity_name="template" entity_id={template_id || ""}>
       <EntityContainer
         title={"Template Overview"}
+        showActivity={false}
         actions={
           <Button variant="outlined" onClick={handleUseTemplate}>
             Use This Template
@@ -36,4 +37,4 @@ export const TemplatePage = () => {
   );
 };
 
-TemplatePage.path = "/templates/:template_id";
+TemplatePage.path = "/templates/:template_id/:tab?";


### PR DESCRIPTION
This PR:

- Makes TabbedContent add active tabs to the URL, if the URL doesn't contain a tab the component will use the defaultTab prop
- Makes the Audit component add the active trace id in the URL for it to be shareable between users, this will have to be changed later together with the fix to the logs.
- Moves `Audit` and `Revision` of templates to TabbedContent instead of dedicated page.

Closes #151 

SourceCodeVersions will be done in a different PR