### PR TITLE
Add timeline view for audit

### DIFF
--- a/ui/frontend-lib/src/common/components/EntityActions.tsx
+++ b/ui/frontend-lib/src/common/components/EntityActions.tsx
@@ -6,6 +6,7 @@ import BugReportIcon from "@mui/icons-material/BugReport";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import EditIcon from "@mui/icons-material/Edit";
 import PendingActionsIcon from "@mui/icons-material/PendingActions";
+import RedoIcon from "@mui/icons-material/Redo";
 import SyncIcon from "@mui/icons-material/Sync";
 import UpdateIcon from "@mui/icons-material/Update";
 import { Button, Tooltip } from "@mui/material";
@@ -140,10 +141,10 @@ export function EntityActions(props: EntityActionsProps) {
       {actions.includes("recreate") && (
         <Button
           variant="outlined"
-          color="secondary"
           onClick={() => changeDialog("recreate")}
+          startIcon={<RedoIcon />}
         >
-          Re-create
+          Recreate
         </Button>
       )}
       {actions.includes("enable") && (
@@ -270,8 +271,8 @@ export function EntityActions(props: EntityActionsProps) {
       />
 
       <CommonDialog
-        title="Request re-create"
-        content="Re-create will return entity back. Do you want to approve the request?"
+        title="Request recreate"
+        content="Recreate will return entity back. Do you want to approve the request?"
         maxWidth="xs"
         actions={
           <ActionButton

--- a/ui/frontend-lib/src/common/components/HorizontalTimeline.tsx
+++ b/ui/frontend-lib/src/common/components/HorizontalTimeline.tsx
@@ -1,0 +1,70 @@
+import { ReactNode } from "react";
+
+import { Box, Stack } from "@mui/material";
+
+export interface HorizontalTimelineItem {
+  id: string;
+}
+
+export interface HorizontalTimelineProps<T extends HorizontalTimelineItem> {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+}
+
+export const HorizontalTimeline = <T extends HorizontalTimelineItem>({
+  items,
+  renderItem,
+}: HorizontalTimelineProps<T>) => {
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", ml: 2 }}>
+      {items.map((item, index) => (
+        <Stack key={item.id} alignItems="center" sx={{ minWidth: 160, pb: 1 }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            sx={{ width: "100%", height: 12 }}
+          >
+            <Box
+              sx={{
+                flex: 1,
+                height: 2,
+                bgcolor: index > 0 ? "text.disabled" : "transparent",
+              }}
+            />
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                borderRadius: "50%",
+                bgcolor: "primary.main",
+                flexShrink: 0,
+              }}
+            />
+            <Box
+              sx={{
+                flex: 1,
+                height: 2,
+                bgcolor:
+                  index < items.length - 1 ? "text.disabled" : "transparent",
+              }}
+            />
+            {index < items.length - 1 && (
+              <Box
+                sx={{
+                  width: 0,
+                  height: 0,
+                  borderTop: "5px solid transparent",
+                  borderBottom: "5px solid transparent",
+                  borderLeft: "6px solid",
+                  borderLeftColor: "text.disabled",
+                  flexShrink: 0,
+                }}
+              />
+            )}
+          </Stack>
+          {renderItem(item, index)}
+        </Stack>
+      ))}
+    </Box>
+  );
+};

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -2,16 +2,22 @@ import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Icon } from "@iconify/react";
 import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import TableRowsIcon from "@mui/icons-material/TableRows";
+import TimelineIcon from "@mui/icons-material/Timeline";
 import {
   Alert,
   Box,
+  Button,
   Card,
   CardContent,
+  Chip,
   IconButton,
-  Link,
   Stack,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
+  Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import {
@@ -28,7 +34,8 @@ import GradientCircularProgress from "../../../common/GradientCircularProgress";
 import { useHashParams } from "../../../common/hooks/useHashParams";
 import { RevisionResponse } from "../../../revision/types";
 import { AuditLogEntity } from "../../../types";
-import { GetReferenceUrlValue } from "../CommonField";
+import { GetEntityLink } from "../CommonField";
+import { HorizontalTimeline } from "../HorizontalTimeline";
 import { RelativeTime } from "../RelativeTime";
 
 import { DiffEditor } from "./DiffEditor";
@@ -42,6 +49,7 @@ export interface AuditProps {
   useVersionId?: boolean;
   sourceCodeLanguage?: string;
   showRevisionColumn?: boolean;
+  showTimelineView?: boolean;
 }
 
 interface AuditFilterPanelProps {
@@ -100,6 +108,7 @@ export const Audit = ({
   useVersionId,
   sourceCodeLanguage,
   showRevisionColumn,
+  showTimelineView,
 }: AuditProps) => {
   const { ikApi } = useConfig();
   const [hashParams, setHashParams] = useHashParams();
@@ -130,6 +139,8 @@ export const Audit = ({
   const [auditLogs, setAuditLogs] = useState<AuditLogEntity[]>([]);
   const [search, setSearch] = useState<string>("");
   const [headerAction, setHeaderAction] = useState<ReactNode>(undefined);
+  const [viewMode, setViewMode] = useState<"table" | "timeline">("table");
+  const [timelineLimit, setTimelineLimit] = useState(3);
 
   const [revisionDialogLeft, setRevisionDialogLeft] =
     useState<RevisionResponse | null>(null);
@@ -221,6 +232,47 @@ export const Audit = ({
       });
   }, [ikApi, entityId]);
 
+  // Search filtering for timeline view (DataGrid handles its own filtering for table view)
+  const filteredLogs = useMemo(() => {
+    const tokens = search.toLowerCase().split(" ").filter(Boolean);
+    if (tokens.length === 0) return auditLogs;
+    return auditLogs.filter((log) =>
+      tokens.every(
+        (token) =>
+          log.action.toLowerCase().includes(token) ||
+          (log.creator?.identifier ?? "system").toLowerCase().includes(token),
+      ),
+    );
+  }, [auditLogs, search]);
+
+  // Groups filtered logs by revision for timeline view, preserving insertion order
+  const groupedByRevision = useMemo(() => {
+    const groups: [string, AuditLogEntity[]][] = [];
+    const map = new Map<string, AuditLogEntity[]>();
+    for (const log of filteredLogs) {
+      // Falls back to "v1" when revision_number is not available
+      const revision = `v${log.revision_number ?? 1}`;
+      if (!map.has(revision)) {
+        const arr: AuditLogEntity[] = [];
+        map.set(revision, arr);
+        groups.push([revision, arr]);
+      }
+      map.get(revision)!.push(log);
+    }
+    return groups;
+  }, [filteredLogs]);
+
+  const openDialog = (rowId: string, view: "summary" | "logs") => {
+    const newParams = new URLSearchParams(hashParams);
+    newParams.set("traceId", rowId);
+    newParams.set("view", view);
+    if (useVersionId) {
+      newParams.set("versionId", entityId);
+    }
+    setHashParams(newParams);
+    setHeaderAction(undefined);
+  };
+
   const columns: GridColDef<AuditLogEntity>[] = useMemo(
     () => [
       ...(showRevisionColumn
@@ -233,16 +285,17 @@ export const Audit = ({
                 const rev = params.row.revision_number;
                 if (!rev) return null;
                 return (
-                  <Link
-                    component="button"
-                    variant="body2"
+                  <Chip
+                    label={`v${rev}`}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    sx={{ cursor: "pointer" }}
                     onClick={(e) => {
                       e.stopPropagation();
                       handleRevisionClick(entityId, rev);
                     }}
-                  >
-                    v{rev}
-                  </Link>
+                  />
                 );
               },
             } as GridColDef<AuditLogEntity>,
@@ -262,7 +315,7 @@ export const Audit = ({
             return "System";
           }
           const creatorData = params.row.creator;
-          return <GetReferenceUrlValue {...creatorData} />;
+          return <GetEntityLink {...creatorData} />;
         },
       },
       {
@@ -277,6 +330,7 @@ export const Audit = ({
         field: "userActions",
         headerName: "",
         flex: 1,
+        sortable: false,
         renderCell: (params) => (
           <Box
             sx={{
@@ -348,60 +402,196 @@ export const Audit = ({
   return (
     <Box>
       <AuditFilterPanel search={search} setSearch={setSearch} />
+      {showTimelineView && (
+        <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
+          <ToggleButtonGroup
+            value={viewMode}
+            exclusive
+            onChange={(_, value) => value && setViewMode(value)}
+            size="small"
+            sx={{ "& .MuiToggleButton-root": { py: 0.5 } }}
+          >
+            <ToggleButton value="table">
+              <Tooltip title="Table view">
+                <TableRowsIcon sx={{ fontSize: "1rem" }} />
+              </Tooltip>
+            </ToggleButton>
+            <ToggleButton value="timeline">
+              <Tooltip title="Timeline view">
+                <TimelineIcon sx={{ fontSize: "1rem" }} />
+              </Tooltip>
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      )}
       <Box>
         <Card sx={{ mt: 2 }}>
           <CardContent>
-            <Box sx={{ width: "100%", overflowX: "auto" }}>
-              <DataGrid
-                rows={auditLogs}
-                columns={columns}
-                pagination
-                disableColumnFilter
-                disableColumnMenu
-                disableRowSelectionOnClick
-                sortModel={sortModel}
-                onSortModelChange={handleSortModelChange}
-                paginationModel={paginationModel}
-                onPaginationModelChange={handlePaginationModelChange}
-                pageSizeOptions={[10, 25, 50, 100]}
-                filterModel={filterModel}
-                onFilterModelChange={setFilterModel}
-                sx={{
-                  "& .MuiDataGrid-columnHeader": {
-                    "& .MuiDataGrid-columnHeaderTitleContainer": {
-                      justifyContent: "space-between",
-                      flexDirection: "row",
-                    },
-                    "& .MuiButtonBase-root": {
-                      border: "none",
-                    },
-                  },
-                  "& .MuiTablePagination-root": {
-                    "& .MuiButtonBase-root": {
-                      border: "none",
-                    },
-                  },
-                  "& .MuiDataGrid-row": {
-                    "&:hover": {
-                      backgroundColor: (theme) =>
-                        alpha(theme.palette.primary.main, 0.08),
-                    },
-                  },
-                }}
-                slotProps={{
-                  pagination: {
-                    SelectProps: {
-                      inputProps: {
-                        "aria-label": "Rows per page",
-                        "aria-labelledby": "audit-pagination-label",
+            <Box sx={{ width: "100%", overflowX: "auto", minHeight: 300 }}>
+              {viewMode === "table" ? (
+                <DataGrid
+                  rows={auditLogs}
+                  columns={columns}
+                  pagination
+                  disableColumnFilter
+                  disableColumnMenu
+                  disableRowSelectionOnClick
+                  sortModel={sortModel}
+                  onSortModelChange={handleSortModelChange}
+                  paginationModel={paginationModel}
+                  onPaginationModelChange={handlePaginationModelChange}
+                  pageSizeOptions={[10, 25, 50, 100]}
+                  filterModel={filterModel}
+                  onFilterModelChange={setFilterModel}
+                  sx={{
+                    "& .MuiDataGrid-columnHeader": {
+                      "& .MuiDataGrid-columnHeaderTitleContainer": {
+                        justifyContent: "space-between",
+                        flexDirection: "row",
                       },
-                      "aria-label": "Rows per page",
+                      "& .MuiButtonBase-root": {
+                        border: "none",
+                      },
                     },
-                    labelRowsPerPage: "Rows per page:",
-                    labelId: "audit-pagination-label",
-                  },
-                }}
-              />
+                    "& .MuiTablePagination-root": {
+                      "& .MuiButtonBase-root": {
+                        border: "none",
+                      },
+                    },
+                    "& .MuiDataGrid-row": {
+                      "&:hover": {
+                        backgroundColor: (theme) =>
+                          alpha(theme.palette.primary.main, 0.08),
+                      },
+                    },
+                  }}
+                  slotProps={{
+                    pagination: {
+                      SelectProps: {
+                        inputProps: {
+                          "aria-label": "Rows per page",
+                          "aria-labelledby": "audit-pagination-label",
+                        },
+                        "aria-label": "Rows per page",
+                      },
+                      labelRowsPerPage: "Rows per page:",
+                      labelId: "audit-pagination-label",
+                    },
+                  }}
+                />
+              ) : (
+                <>
+                  {groupedByRevision
+                    .slice(0, timelineLimit)
+                    .map(([revision, logs]) => (
+                      <Box key={revision} sx={{ mb: 3 }}>
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                          <Chip
+                            label={revision}
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{
+                              cursor:
+                                showRevisionColumn && logs[0].revision_number
+                                  ? "pointer"
+                                  : "default",
+                            }}
+                            onClick={() => {
+                              if (
+                                showRevisionColumn &&
+                                logs[0].revision_number
+                              ) {
+                                handleRevisionClick(
+                                  entityId,
+                                  logs[0].revision_number,
+                                );
+                              }
+                            }}
+                          />
+                          <RelativeTime
+                            date={logs[0].created_at}
+                            sx={{ fontSize: "0.75rem" }}
+                          />
+                        </Stack>
+                        <Box sx={{ mt: 3 }}>
+                          <HorizontalTimeline
+                            items={[...logs].reverse()}
+                            renderItem={(log) => (
+                              <>
+                                <Typography
+                                  variant="body2"
+                                  fontWeight={500}
+                                  sx={{ mt: 0.5 }}
+                                >
+                                  {log.action}
+                                </Typography>
+                                <RelativeTime
+                                  date={log.created_at}
+                                  user={log.creator}
+                                  sx={{ fontSize: "0.7rem" }}
+                                />
+                                {actionsWithLogs.includes(log.action) && (
+                                  <Stack
+                                    direction="row"
+                                    spacing={0.25}
+                                    sx={{
+                                      mt: 0.25,
+                                      "& .MuiIconButton-root": {
+                                        border: "none",
+                                      },
+                                    }}
+                                  >
+                                    {log.action !== "sync" &&
+                                      isTerraformLanguage(
+                                        sourceCodeLanguage,
+                                      ) && (
+                                        <Tooltip title="Summary">
+                                          <IconButton
+                                            size="small"
+                                            onClick={() =>
+                                              openDialog(log.id, "summary")
+                                            }
+                                          >
+                                            <AutoAwesomeIcon
+                                              sx={{ fontSize: "1rem" }}
+                                            />
+                                          </IconButton>
+                                        </Tooltip>
+                                      )}
+                                    <Tooltip title="Logs">
+                                      <IconButton
+                                        size="small"
+                                        onClick={() =>
+                                          openDialog(log.id, "logs")
+                                        }
+                                      >
+                                        <Icon icon="ix:log" width={16} />
+                                      </IconButton>
+                                    </Tooltip>
+                                  </Stack>
+                                )}
+                              </>
+                            )}
+                          />
+                        </Box>
+                      </Box>
+                    ))}
+                  {groupedByRevision.length > 0 && (
+                    <Box
+                      sx={{ display: "flex", justifyContent: "center", mt: 2 }}
+                    >
+                      <Button
+                        variant="text"
+                        disabled={groupedByRevision.length <= timelineLimit}
+                        onClick={() => setTimelineLimit((prev) => prev + 3)}
+                      >
+                        Show more
+                      </Button>
+                    </Box>
+                  )}
+                </>
+              )}
               {logsOpen && selectedTraceId && selectedView && (
                 <CommonDialog
                   title={getDialogTitle(selectedView, selectedAction)}

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -229,19 +229,6 @@ export const Audit = ({
       });
   }, [ikApi, entityId]);
 
-  // Search filtering for timeline view (DataGrid handles its own filtering for table view)
-  const filteredLogs = useMemo(() => {
-    const tokens = search.toLowerCase().split(" ").filter(Boolean);
-    if (tokens.length === 0) return auditLogs;
-    return auditLogs.filter((log) =>
-      tokens.every(
-        (token) =>
-          log.action.toLowerCase().includes(token) ||
-          (log.creator?.identifier ?? "system").toLowerCase().includes(token),
-      ),
-    );
-  }, [auditLogs, search]);
-
   const openDialog = useCallback(
     (rowId: string, view: "summary" | "logs") => {
       const newParams = new URLSearchParams(hashParams);
@@ -369,31 +356,31 @@ export const Audit = ({
   return (
     <Box>
       <AuditFilterPanel search={search} setSearch={setSearch} />
-      {showTimelineView && (
-        <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2 }}>
-          <ToggleButtonGroup
-            value={viewMode}
-            exclusive
-            onChange={(_, value) => value && setViewMode(value)}
-            size="small"
-            sx={{ "& .MuiToggleButton-root": { py: 0.5 } }}
-          >
-            <ToggleButton value="table">
-              <Tooltip title="Table view">
-                <TableRowsIcon sx={{ fontSize: "1rem" }} />
-              </Tooltip>
-            </ToggleButton>
-            <ToggleButton value="timeline">
-              <Tooltip title="Timeline view">
-                <TimelineIcon sx={{ fontSize: "1rem" }} />
-              </Tooltip>
-            </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
-      )}
       <Box>
         <Card sx={{ mt: 2 }}>
           <CardContent>
+            {showTimelineView && (
+              <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+                <ToggleButtonGroup
+                  value={viewMode}
+                  exclusive
+                  onChange={(_, value) => value && setViewMode(value)}
+                  size="small"
+                  sx={{ "& .MuiToggleButton-root": { py: 0.5 } }}
+                >
+                  <ToggleButton value="table">
+                    <Tooltip title="Table view">
+                      <TableRowsIcon sx={{ fontSize: "1rem" }} />
+                    </Tooltip>
+                  </ToggleButton>
+                  <ToggleButton value="timeline">
+                    <Tooltip title="Timeline view">
+                      <TimelineIcon sx={{ fontSize: "1rem" }} />
+                    </Tooltip>
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+            )}
             <Box sx={{ width: "100%", overflowX: "auto", minHeight: 300 }}>
               {viewMode === "table" ? (
                 <DataGrid
@@ -448,7 +435,8 @@ export const Audit = ({
                 />
               ) : (
                 <RevisionTimelines
-                  logs={filteredLogs}
+                  logs={auditLogs}
+                  search={search}
                   actionsWithLogs={actionsWithLogs}
                   onRevisionClick={(rev) => handleRevisionClick(entityId, rev)}
                   onOpenDialog={openDialog}

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -349,14 +349,7 @@ export const Audit = ({
                         size="small"
                         onClick={(e) => {
                           e.stopPropagation();
-                          const newParams = new URLSearchParams(hashParams);
-                          newParams.set("traceId", params.row.id);
-                          newParams.set("view", "summary");
-                          if (useVersionId) {
-                            newParams.set("versionId", entityId);
-                          }
-                          setHashParams(newParams);
-                          setHeaderAction(undefined);
+                          openDialog(params.row.id, "summary");
                         }}
                       >
                         <AutoAwesomeIcon fontSize="small" />
@@ -368,14 +361,7 @@ export const Audit = ({
                     size="small"
                     onClick={(e) => {
                       e.stopPropagation();
-                      const newParams = new URLSearchParams(hashParams);
-                      newParams.set("traceId", params.row.id);
-                      newParams.set("view", "logs");
-                      if (useVersionId) {
-                        newParams.set("versionId", entityId);
-                      }
-                      setHashParams(newParams);
-                      setHeaderAction(undefined);
+                      openDialog(params.row.id, "logs");
                     }}
                   >
                     <Icon icon="ix:log" />
@@ -389,9 +375,7 @@ export const Audit = ({
     ],
     [
       actionsWithLogs,
-      hashParams,
-      setHashParams,
-      useVersionId,
+      openDialog,
       entityId,
       sourceCodeLanguage,
       showRevisionColumn,

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -17,7 +17,6 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
-  Typography,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 import {
@@ -35,11 +34,11 @@ import { useHashParams } from "../../../common/hooks/useHashParams";
 import { RevisionResponse } from "../../../revision/types";
 import { AuditLogEntity } from "../../../types";
 import { GetEntityLink } from "../CommonField";
-import { HorizontalTimeline } from "../HorizontalTimeline";
 import { RelativeTime } from "../RelativeTime";
 
 import { DiffEditor } from "./DiffEditor";
 import { Logs } from "./Logs";
+import { RevisionTimeline } from "./RevisionTimeline";
 
 const isTerraformLanguage = (lang?: string): boolean =>
   lang === "opentofu" || lang === "terraform";
@@ -262,16 +261,19 @@ export const Audit = ({
     return groups;
   }, [filteredLogs]);
 
-  const openDialog = (rowId: string, view: "summary" | "logs") => {
-    const newParams = new URLSearchParams(hashParams);
-    newParams.set("traceId", rowId);
-    newParams.set("view", view);
-    if (useVersionId) {
-      newParams.set("versionId", entityId);
-    }
-    setHashParams(newParams);
-    setHeaderAction(undefined);
-  };
+  const openDialog = useCallback(
+    (rowId: string, view: "summary" | "logs") => {
+      const newParams = new URLSearchParams(hashParams);
+      newParams.set("traceId", rowId);
+      newParams.set("view", view);
+      if (useVersionId) {
+        newParams.set("versionId", entityId);
+      }
+      setHashParams(newParams);
+      setHeaderAction(undefined);
+    },
+    [hashParams, setHashParams, useVersionId, entityId],
+  );
 
   const columns: GridColDef<AuditLogEntity>[] = useMemo(
     () => [
@@ -468,98 +470,16 @@ export const Audit = ({
                   {groupedByRevision
                     .slice(0, timelineLimit)
                     .map(([revision, logs]) => (
-                      <Box key={revision} sx={{ mb: 3 }}>
-                        <Stack direction="row" alignItems="center" spacing={1}>
-                          <Chip
-                            label={revision}
-                            size="small"
-                            color="primary"
-                            variant="outlined"
-                            sx={{
-                              cursor:
-                                showRevisionColumn && logs[0].revision_number
-                                  ? "pointer"
-                                  : "default",
-                            }}
-                            onClick={() => {
-                              if (
-                                showRevisionColumn &&
-                                logs[0].revision_number
-                              ) {
-                                handleRevisionClick(
-                                  entityId,
-                                  logs[0].revision_number,
-                                );
-                              }
-                            }}
-                          />
-                          <RelativeTime
-                            date={logs[0].created_at}
-                            sx={{ fontSize: "0.75rem" }}
-                          />
-                        </Stack>
-                        <Box sx={{ mt: 3 }}>
-                          <HorizontalTimeline
-                            items={[...logs].reverse()}
-                            renderItem={(log) => (
-                              <>
-                                <Typography
-                                  variant="body2"
-                                  fontWeight={500}
-                                  sx={{ mt: 0.5 }}
-                                >
-                                  {log.action}
-                                </Typography>
-                                <RelativeTime
-                                  date={log.created_at}
-                                  user={log.creator}
-                                  sx={{ fontSize: "0.7rem" }}
-                                />
-                                {actionsWithLogs.includes(log.action) && (
-                                  <Stack
-                                    direction="row"
-                                    spacing={0.25}
-                                    sx={{
-                                      mt: 0.25,
-                                      "& .MuiIconButton-root": {
-                                        border: "none",
-                                      },
-                                    }}
-                                  >
-                                    {log.action !== "sync" &&
-                                      isTerraformLanguage(
-                                        sourceCodeLanguage,
-                                      ) && (
-                                        <Tooltip title="Summary">
-                                          <IconButton
-                                            size="small"
-                                            onClick={() =>
-                                              openDialog(log.id, "summary")
-                                            }
-                                          >
-                                            <AutoAwesomeIcon
-                                              sx={{ fontSize: "1rem" }}
-                                            />
-                                          </IconButton>
-                                        </Tooltip>
-                                      )}
-                                    <Tooltip title="Logs">
-                                      <IconButton
-                                        size="small"
-                                        onClick={() =>
-                                          openDialog(log.id, "logs")
-                                        }
-                                      >
-                                        <Icon icon="ix:log" width={16} />
-                                      </IconButton>
-                                    </Tooltip>
-                                  </Stack>
-                                )}
-                              </>
-                            )}
-                          />
-                        </Box>
-                      </Box>
+                      <RevisionTimeline
+                        key={revision}
+                        revision={revision}
+                        logs={logs}
+                        actionsWithLogs={actionsWithLogs}
+                        onRevisionClick={(rev) =>
+                          handleRevisionClick(entityId, rev)
+                        }
+                        onOpenDialog={openDialog}
+                      />
                     ))}
                   {groupedByRevision.length > 0 && (
                     <Box

--- a/ui/frontend-lib/src/common/components/activity/Audit.tsx
+++ b/ui/frontend-lib/src/common/components/activity/Audit.tsx
@@ -7,7 +7,6 @@ import TimelineIcon from "@mui/icons-material/Timeline";
 import {
   Alert,
   Box,
-  Button,
   Card,
   CardContent,
   Chip,
@@ -38,7 +37,7 @@ import { RelativeTime } from "../RelativeTime";
 
 import { DiffEditor } from "./DiffEditor";
 import { Logs } from "./Logs";
-import { RevisionTimeline } from "./RevisionTimeline";
+import { RevisionTimelines } from "./RevisionTimelines";
 
 const isTerraformLanguage = (lang?: string): boolean =>
   lang === "opentofu" || lang === "terraform";
@@ -139,7 +138,6 @@ export const Audit = ({
   const [search, setSearch] = useState<string>("");
   const [headerAction, setHeaderAction] = useState<ReactNode>(undefined);
   const [viewMode, setViewMode] = useState<"table" | "timeline">("table");
-  const [timelineLimit, setTimelineLimit] = useState(3);
 
   const [revisionDialogLeft, setRevisionDialogLeft] =
     useState<RevisionResponse | null>(null);
@@ -243,23 +241,6 @@ export const Audit = ({
       ),
     );
   }, [auditLogs, search]);
-
-  // Groups filtered logs by revision for timeline view, preserving insertion order
-  const groupedByRevision = useMemo(() => {
-    const groups: [string, AuditLogEntity[]][] = [];
-    const map = new Map<string, AuditLogEntity[]>();
-    for (const log of filteredLogs) {
-      // Falls back to "v1" when revision_number is not available
-      const revision = `v${log.revision_number ?? 1}`;
-      if (!map.has(revision)) {
-        const arr: AuditLogEntity[] = [];
-        map.set(revision, arr);
-        groups.push([revision, arr]);
-      }
-      map.get(revision)!.push(log);
-    }
-    return groups;
-  }, [filteredLogs]);
 
   const openDialog = useCallback(
     (rowId: string, view: "summary" | "logs") => {
@@ -466,35 +447,12 @@ export const Audit = ({
                   }}
                 />
               ) : (
-                <>
-                  {groupedByRevision
-                    .slice(0, timelineLimit)
-                    .map(([revision, logs]) => (
-                      <RevisionTimeline
-                        key={revision}
-                        revision={revision}
-                        logs={logs}
-                        actionsWithLogs={actionsWithLogs}
-                        onRevisionClick={(rev) =>
-                          handleRevisionClick(entityId, rev)
-                        }
-                        onOpenDialog={openDialog}
-                      />
-                    ))}
-                  {groupedByRevision.length > 0 && (
-                    <Box
-                      sx={{ display: "flex", justifyContent: "center", mt: 2 }}
-                    >
-                      <Button
-                        variant="text"
-                        disabled={groupedByRevision.length <= timelineLimit}
-                        onClick={() => setTimelineLimit((prev) => prev + 3)}
-                      >
-                        Show more
-                      </Button>
-                    </Box>
-                  )}
-                </>
+                <RevisionTimelines
+                  logs={filteredLogs}
+                  actionsWithLogs={actionsWithLogs}
+                  onRevisionClick={(rev) => handleRevisionClick(entityId, rev)}
+                  onOpenDialog={openDialog}
+                />
               )}
               {logsOpen && selectedTraceId && selectedView && (
                 <CommonDialog

--- a/ui/frontend-lib/src/common/components/activity/RevisionTimeline.tsx
+++ b/ui/frontend-lib/src/common/components/activity/RevisionTimeline.tsx
@@ -1,0 +1,100 @@
+import { Icon } from "@iconify/react";
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
+import {
+  Box,
+  Chip,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+
+import { AuditLogEntity } from "../../../types";
+import { HorizontalTimeline } from "../HorizontalTimeline";
+import { RelativeTime } from "../RelativeTime";
+
+interface RevisionTimelineProps {
+  revision: string;
+  logs: AuditLogEntity[];
+  actionsWithLogs: string[];
+  onRevisionClick?: (revisionNumber: number) => void;
+  onOpenDialog: (rowId: string, view: "summary" | "logs") => void;
+}
+
+export const RevisionTimeline = ({
+  revision,
+  logs,
+  actionsWithLogs,
+  onRevisionClick,
+  onOpenDialog,
+}: RevisionTimelineProps) => {
+  return (
+    <Box sx={{ mb: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Chip
+          label={revision}
+          size="small"
+          color="primary"
+          variant="outlined"
+          sx={{
+            cursor: logs[0].revision_number ? "pointer" : "default",
+          }}
+          onClick={() => {
+            if (logs[0].revision_number && onRevisionClick) {
+              onRevisionClick(logs[0].revision_number);
+            }
+          }}
+        />
+        <RelativeTime date={logs[0].created_at} sx={{ fontSize: "0.75rem" }} />
+      </Stack>
+      <Box sx={{ mt: 3 }}>
+        <HorizontalTimeline
+          items={[...logs].reverse()}
+          renderItem={(log) => (
+            <>
+              <Typography variant="body2" fontWeight={500} sx={{ mt: 0.5 }}>
+                {log.action}
+              </Typography>
+              <RelativeTime
+                date={log.created_at}
+                user={log.creator}
+                sx={{ fontSize: "0.7rem" }}
+              />
+              {actionsWithLogs.includes(log.action) && (
+                <Stack
+                  direction="row"
+                  spacing={0.25}
+                  sx={{
+                    mt: 0.25,
+                    "& .MuiIconButton-root": {
+                      border: "none",
+                    },
+                  }}
+                >
+                  {log.action !== "sync" && (
+                    <Tooltip title="Summary">
+                      <IconButton
+                        size="small"
+                        onClick={() => onOpenDialog(log.id, "summary")}
+                      >
+                        <AutoAwesomeIcon sx={{ fontSize: "1rem" }} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  <Tooltip title="Logs">
+                    <IconButton
+                      size="small"
+                      onClick={() => onOpenDialog(log.id, "logs")}
+                    >
+                      <Icon icon="ix:log" width={16} />
+                    </IconButton>
+                  </Tooltip>
+                </Stack>
+              )}
+            </>
+          )}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/ui/frontend-lib/src/common/components/activity/RevisionTimelines.tsx
+++ b/ui/frontend-lib/src/common/components/activity/RevisionTimelines.tsx
@@ -8,6 +8,7 @@ import { RevisionTimeline } from "./RevisionTimeline";
 
 interface RevisionTimelinesProps {
   logs: AuditLogEntity[];
+  search: string;
   actionsWithLogs: string[];
   onRevisionClick?: (revisionNumber: number) => void;
   onOpenDialog: (rowId: string, view: "summary" | "logs") => void;
@@ -15,17 +16,31 @@ interface RevisionTimelinesProps {
 
 export const RevisionTimelines = ({
   logs,
+  search,
   actionsWithLogs,
   onRevisionClick,
   onOpenDialog,
 }: RevisionTimelinesProps) => {
   const [limit, setLimit] = useState(3);
 
+  // Search filtering for timeline view
+  const filteredLogs = useMemo(() => {
+    const tokens = search.toLowerCase().split(" ").filter(Boolean);
+    if (tokens.length === 0) return logs;
+    return logs.filter((log) =>
+      tokens.every(
+        (token) =>
+          log.action.toLowerCase().includes(token) ||
+          (log.creator?.identifier ?? "system").toLowerCase().includes(token),
+      ),
+    );
+  }, [logs, search]);
+
   // Groups logs by revision, preserving insertion order
   const groups = useMemo(() => {
     const result: [string, AuditLogEntity[]][] = [];
     const map = new Map<string, AuditLogEntity[]>();
-    for (const log of logs) {
+    for (const log of filteredLogs) {
       // Falls back to "v1" when revision_number is not available
       const revision = `v${log.revision_number ?? 1}`;
       if (!map.has(revision)) {
@@ -36,7 +51,7 @@ export const RevisionTimelines = ({
       map.get(revision)!.push(log);
     }
     return result;
-  }, [logs]);
+  }, [filteredLogs]);
 
   return (
     <>

--- a/ui/frontend-lib/src/common/components/activity/RevisionTimelines.tsx
+++ b/ui/frontend-lib/src/common/components/activity/RevisionTimelines.tsx
@@ -1,0 +1,66 @@
+import { useMemo, useState } from "react";
+
+import { Box, Button } from "@mui/material";
+
+import { AuditLogEntity } from "../../../types";
+
+import { RevisionTimeline } from "./RevisionTimeline";
+
+interface RevisionTimelinesProps {
+  logs: AuditLogEntity[];
+  actionsWithLogs: string[];
+  onRevisionClick?: (revisionNumber: number) => void;
+  onOpenDialog: (rowId: string, view: "summary" | "logs") => void;
+}
+
+export const RevisionTimelines = ({
+  logs,
+  actionsWithLogs,
+  onRevisionClick,
+  onOpenDialog,
+}: RevisionTimelinesProps) => {
+  const [limit, setLimit] = useState(3);
+
+  // Groups logs by revision, preserving insertion order
+  const groups = useMemo(() => {
+    const result: [string, AuditLogEntity[]][] = [];
+    const map = new Map<string, AuditLogEntity[]>();
+    for (const log of logs) {
+      // Falls back to "v1" when revision_number is not available
+      const revision = `v${log.revision_number ?? 1}`;
+      if (!map.has(revision)) {
+        const arr: AuditLogEntity[] = [];
+        map.set(revision, arr);
+        result.push([revision, arr]);
+      }
+      map.get(revision)!.push(log);
+    }
+    return result;
+  }, [logs]);
+
+  return (
+    <>
+      {groups.slice(0, limit).map(([revision, logs]) => (
+        <RevisionTimeline
+          key={revision}
+          revision={revision}
+          logs={logs}
+          actionsWithLogs={actionsWithLogs}
+          onRevisionClick={onRevisionClick}
+          onOpenDialog={onOpenDialog}
+        />
+      ))}
+      {groups.length > 0 && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+          <Button
+            variant="text"
+            disabled={groups.length <= limit}
+            onClick={() => setLimit((prev) => prev + 3)}
+          >
+            Show more
+          </Button>
+        </Box>
+      )}
+    </>
+  );
+};

--- a/ui/frontend-lib/src/common/components/index.ts
+++ b/ui/frontend-lib/src/common/components/index.ts
@@ -4,6 +4,7 @@ export * from "./filter_panel/FilterComponents";
 export * from "./filter_panel/FilterConfig";
 export * from "./filter_panel/FilterRenderer";
 export * from "./GlobalNotificationPopup";
+export * from "./HorizontalTimeline";
 export * from "./inputs";
 export * from "./notifications";
 export * from "./UserAvatar";

--- a/ui/frontend-lib/src/resources/components/ResourceContent.tsx
+++ b/ui/frontend-lib/src/resources/components/ResourceContent.tsx
@@ -50,6 +50,7 @@ export const ResourceContent = () => {
             entity.source_code_version?.source_code?.source_code_language
           }
           showRevisionColumn
+          showTimelineView
         />
       ),
     },


### PR DESCRIPTION
For resource audit, user can switch between table view and timeline view:

<img width="1201" height="560" alt="Screenshot 2026-04-14 at 13 49 06" src="https://github.com/user-attachments/assets/03fb5d23-d142-4d79-b33b-c46385009fae" />

<img width="1189" height="331" alt="Screenshot 2026-04-14 at 13 49 21" src="https://github.com/user-attachments/assets/dbf0f5be-f2d2-41dc-8271-820723b53707" />
