### PR TITLE
IK-202 Fix filter panel

### DIFF
--- a/ui/frontend-lib/src/common/components/filter_panel/FilterComponents.tsx
+++ b/ui/frontend-lib/src/common/components/filter_panel/FilterComponents.tsx
@@ -209,6 +209,30 @@ export const CascadingFilter = ({
 
   const optionsLength = loadedOptions.length;
 
+  // When loadedOptions has populated but the stored value's top-level option is
+  // missing (e.g. not on the first page), fetch it by value.
+  // Uses loadOptionByValue if provided, otherwise falls back to loadOptions.
+  useEffect(() => {
+    if (!value || loadedOptions.length === 0) return;
+    const topValue = Array.isArray(value) ? value[0] : value;
+    if (loadedOptions.some((o) => o.value === topValue)) return;
+
+    const fetch = config.loadOptionByValue
+      ? config.loadOptionByValue(topValue).then((opt) => (opt ? [opt] : []))
+      : (loadOptions?.(topValue, 1).then((r) => r.options) ??
+        Promise.resolve([]));
+
+    fetch.then((opts) =>
+      setLoadedOptions((prev) => {
+        const incoming = opts.filter(
+          (o) => !prev.some((p) => p.value === o.value),
+        );
+        return incoming.length > 0 ? [...incoming, ...prev] : prev;
+      }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, optionsLength]);
+
   // Effect to handle initial value resolution (loading children if path is provided as array)
   useEffect(() => {
     const resolvePath = async () => {

--- a/ui/frontend-lib/src/common/components/filter_panel/FilterConfig.ts
+++ b/ui/frontend-lib/src/common/components/filter_panel/FilterConfig.ts
@@ -50,6 +50,7 @@ export interface CascadingFilterConfig extends BaseFilterConfig {
     search: string,
     page: number,
   ) => Promise<{ options: CascadingOption[]; hasMore: boolean }>;
+  loadOptionByValue?: (value: string) => Promise<CascadingOption | null>;
 }
 
 export type FilterConfig =

--- a/ui/frontend-lib/src/resources/components/resourceTableConfig.tsx
+++ b/ui/frontend-lib/src/resources/components/resourceTableConfig.tsx
@@ -394,6 +394,13 @@ interface ResourceFilterConfigProps {
     }>;
     hasMore: boolean;
   }>;
+  loadTemplateOptionByValue?: (value: string) => Promise<{
+    label: string;
+    value: string;
+    loadChildren?: (
+      parentValue: string,
+    ) => Promise<Array<{ label: string; value: string }>>;
+  } | null>;
   versionOptions?: string[];
   showTemplateVersionFilter: boolean;
 }
@@ -401,6 +408,7 @@ interface ResourceFilterConfigProps {
 export const createResourceFilterConfigs = ({
   labels,
   loadTemplateOptions,
+  loadTemplateOptionByValue,
   versionOptions = [] as string[],
   showTemplateVersionFilter,
 }: ResourceFilterConfigProps): FilterConfig[] => {
@@ -410,6 +418,7 @@ export const createResourceFilterConfigs = ({
         type: "cascading",
         label: "Template & Version",
         loadOptions: loadTemplateOptions,
+        loadOptionByValue: loadTemplateOptionByValue,
         width: 420,
       }
     : {

--- a/ui/frontend-lib/src/resources/pages/Resources.tsx
+++ b/ui/frontend-lib/src/resources/pages/Resources.tsx
@@ -30,6 +30,33 @@ export const ResourcesPage = () => {
     });
   }, [ikApi]);
 
+  const makeTemplateOption = useCallback(
+    (template: { id: string; name: string }) => ({
+      label: template.name,
+      value: `template:${template.id}`,
+      loadChildren: async (parentValue: string) => {
+        const templateId = parentValue.replace("template:", "");
+        try {
+          const scvResponse = await ikApi.getList("source_code_versions", {
+            filter: { template_id: templateId },
+            pagination: { page: 1, perPage: 1000 },
+            fields: ["id", "source_code_version", "source_code_branch"],
+          });
+          return scvResponse.data
+            .map((version: any) => ({
+              label: version.source_code_version ?? version.source_code_branch,
+              value: `scv:${version.id}:${templateId}`,
+            }))
+            .sort((a: any, b: any) => a.label.localeCompare(b.label));
+        } catch {
+          notifyError("Failed to load versions");
+          return [];
+        }
+      },
+    }),
+    [ikApi],
+  );
+
   const loadTemplateOptions = useCallback(
     async (search: string, page: number) => {
       const perPage = 10;
@@ -39,38 +66,25 @@ export const ResourcesPage = () => {
         sort: { field: "name", order: "ASC" },
         filter: search ? { name__like: search } : {},
       });
-      const options = response.data.map(
-        (template: { id: string; name: string }) => ({
-          label: template.name,
-          value: `template:${template.id}`,
-          loadChildren: async (parentValue: string) => {
-            const templateId = parentValue.replace("template:", "");
-            try {
-              const scvResponse = await ikApi.getList("source_code_versions", {
-                filter: { template_id: templateId },
-                pagination: { page: 1, perPage: 1000 },
-                fields: ["id", "source_code_version", "source_code_branch"],
-              });
-              return scvResponse.data
-                .map((version: any) => ({
-                  label:
-                    version.source_code_version ?? version.source_code_branch,
-                  value: `scv:${version.id}:${templateId}`,
-                }))
-                .sort((a: any, b: any) => a.label.localeCompare(b.label));
-            } catch {
-              notifyError("Failed to load versions");
-              return [];
-            }
-          },
-        }),
-      );
       return {
-        options,
+        options: response.data.map(makeTemplateOption),
         hasMore: response.data.length === perPage,
       };
     },
-    [ikApi],
+    [ikApi, makeTemplateOption],
+  );
+
+  const loadTemplateOptionByValue = useCallback(
+    async (value: string) => {
+      const id = value.replace("template:", "");
+      try {
+        const template = await ikApi.get(`templates/${id}`);
+        return template ? makeTemplateOption(template) : null;
+      } catch {
+        return null;
+      }
+    },
+    [ikApi, makeTemplateOption],
   );
 
   const initialFilter = location.state?.filters;
@@ -80,9 +94,10 @@ export const ResourcesPage = () => {
     return createResourceFilterConfigs({
       labels,
       loadTemplateOptions,
+      loadTemplateOptionByValue,
       showTemplateVersionFilter: true,
     });
-  }, [labels, loadTemplateOptions]);
+  }, [labels, loadTemplateOptions, loadTemplateOptionByValue]);
 
   const buildApiFilters = useCallback((filterValues: Record<string, any>) => {
     return buildResourceApiFilters(filterValues);


### PR DESCRIPTION
If the selected template was not in the first 10 options of the `Template & Version` filter then the field remaind empty upon page refresh. I've added a direct fetch to get the template by ID if it was not within the first 10 items.