### PR TITLE
Fix review variable order in Resources

### DIFF
--- a/ui/frontend-lib/src/resources/components/TemplateConfiguration.tsx
+++ b/ui/frontend-lib/src/resources/components/TemplateConfiguration.tsx
@@ -55,7 +55,7 @@ const getSourceCodeVariables = (
         </TableRow>
       </TableHead>
       <TableBody>
-        {variables
+        {[...variables]
           .sort((a, b) => a.name.localeCompare(b.name))
           .map((variable) => (
             <TableRow key={variable.name}>


### PR DESCRIPTION
Fixes a problem where resource review variables weren't ordered the same in the Resource and ResourceTempState:

<img width="1613" height="1314" alt="image" src="https://github.com/user-attachments/assets/26b652dc-a0e1-4630-9fce-327926762e54" />