### PR TITLE
Update notifications to automatically stack.

### DIFF
--- a/ui/app/sign-in-side/components/SignInCard.tsx
+++ b/ui/app/sign-in-side/components/SignInCard.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { useEffectOnce } from "react-use";
 
+import { notify } from "@electrolux-oss/infrakitchen";
 import { Icon } from "@iconify/react";
 import { CircularProgress, Menu, MenuItem } from "@mui/material";
 import Box from "@mui/material/Box";
@@ -10,7 +11,6 @@ import Button from "@mui/material/Button";
 import MuiCard from "@mui/material/Card";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useSnackbar } from "notistack";
 
 import { useAuth } from "../../base/auth/AuthContext";
 
@@ -52,16 +52,13 @@ export default function SignInCard() {
     setAnchorEl(null); // Explicit close
   };
 
-  const { enqueueSnackbar } = useSnackbar();
   const { login, user } = useAuth();
 
   const handleSubmit = (provider: string) => {
     setLoading(true);
     login(provider).catch((error: Error) => {
       setLoading(false);
-      enqueueSnackbar(error?.message || "Login failed. Please try again.", {
-        variant: "error",
-      });
+      notify(error?.message || "Login failed. Please try again.", "error");
     });
   };
 

--- a/ui/frontend-lib/package.json
+++ b/ui/frontend-lib/package.json
@@ -49,7 +49,6 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "moment": "^2.30.1",
-    "notistack": "^3.0.2",
     "prettier": "~3.6.2",
     "query-string": "^9.3.1",
     "react": "^19.2.5",
@@ -59,6 +58,7 @@
     "react-infinite-scroll-component": "^6.1.1",
     "react-router": "^7.14.1",
     "react-use": "^17.6.0",
+    "sonner": "^2.0.7",
     "typescript": "^5.9.3",
     "vite": "^7.3.2",
     "vite-plugin-dts": "^4.5.4"

--- a/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
+++ b/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
@@ -39,10 +39,7 @@ export const GlobalNotificationPopup = () => {
 
     const finalMessage = title && title !== body ? `${title}: ${body}` : body;
 
-    notify(finalMessage, severity, {
-      autoHideDuration: 8000,
-      preventDuplicate: false,
-    });
+    notify(finalMessage, severity, { duration: 8000 });
   }, [notification]);
 
   return null;

--- a/ui/frontend-lib/src/common/components/filter_panel/FilterComponents.tsx
+++ b/ui/frontend-lib/src/common/components/filter_panel/FilterComponents.tsx
@@ -255,7 +255,7 @@ export const CascadingFilter = ({
             newOptions[optionIdx] = { ...option, children };
             updated = true;
           } catch (error) {
-            notifyError(error, { preventDuplicate: true });
+            notifyError(error);
             break;
           }
         }
@@ -279,7 +279,7 @@ export const CascadingFilter = ({
         setLoadedOptions(result.options);
         setHasMore(result.hasMore);
       } catch (error) {
-        notifyError(error, { preventDuplicate: true });
+        notifyError(error);
       } finally {
         setLoadingTop(false);
       }
@@ -304,7 +304,7 @@ export const CascadingFilter = ({
       setHasMore(result.hasMore);
       setPage(nextPage);
     } catch (error) {
-      notifyError(error, { preventDuplicate: true });
+      notifyError(error);
     } finally {
       setLoadingMore(false);
     }

--- a/ui/frontend-lib/src/common/components/notifications/DependenciesError.tsx
+++ b/ui/frontend-lib/src/common/components/notifications/DependenciesError.tsx
@@ -8,7 +8,7 @@ import CardActions from "@mui/material/CardActions";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useSnackbar, SnackbarContent } from "notistack";
+import { toast } from "sonner";
 
 import { IkEntity } from "../../../types";
 import { ExpandIconButton } from "../buttons/ExpandIconButton";
@@ -34,7 +34,6 @@ const StyledCardActions = styled(CardActions)({
 export const DependencyError = forwardRef<HTMLDivElement, DependencyErrorProps>(
   (props, ref) => {
     const { id, message, metadata } = props;
-    const { closeSnackbar } = useSnackbar();
     const [expanded, setExpanded] = useState(true);
 
     const handleExpandClick = useCallback(() => {
@@ -42,11 +41,11 @@ export const DependencyError = forwardRef<HTMLDivElement, DependencyErrorProps>(
     }, []);
 
     const handleDismiss = useCallback(() => {
-      closeSnackbar(id);
-    }, [id, closeSnackbar]);
+      toast.dismiss(id);
+    }, [id]);
 
     return (
-      <SnackbarContent ref={ref} role="alert">
+      <div ref={ref} role="alert">
         <StyledCard
           sx={{
             border: `1px solid`,
@@ -101,7 +100,7 @@ export const DependencyError = forwardRef<HTMLDivElement, DependencyErrorProps>(
             </Paper>
           </Collapse>
         </StyledCard>
-      </SnackbarContent>
+      </div>
     );
   },
 );

--- a/ui/frontend-lib/src/common/components/notifications/ErrorWithStatusCode.tsx
+++ b/ui/frontend-lib/src/common/components/notifications/ErrorWithStatusCode.tsx
@@ -8,7 +8,7 @@ import CardActions from "@mui/material/CardActions";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useSnackbar, SnackbarContent } from "notistack";
+import { toast } from "sonner";
 
 import { ExpandIconButton } from "../buttons/ExpandIconButton";
 
@@ -34,7 +34,6 @@ export const ErrorWithStatusCode = forwardRef<
   ErrorWithCodeProps
 >((props, ref) => {
   const { id, message, metadata } = props;
-  const { closeSnackbar } = useSnackbar();
   const [expanded, setExpanded] = useState(true);
 
   const handleExpandClick = useCallback(() => {
@@ -42,11 +41,11 @@ export const ErrorWithStatusCode = forwardRef<
   }, []);
 
   const handleDismiss = useCallback(() => {
-    closeSnackbar(id);
-  }, [id, closeSnackbar]);
+    toast.dismiss(id);
+  }, [id]);
 
   return (
-    <SnackbarContent ref={ref} role="alert">
+    <div ref={ref} role="alert">
       <StyledCard
         sx={{
           border: `1px solid`,
@@ -105,7 +104,7 @@ export const ErrorWithStatusCode = forwardRef<
           </Paper>
         </Collapse>
       </StyledCard>
-    </SnackbarContent>
+    </div>
   );
 });
 

--- a/ui/frontend-lib/src/common/components/notifications/NotificationContent.tsx
+++ b/ui/frontend-lib/src/common/components/notifications/NotificationContent.tsx
@@ -6,7 +6,7 @@ import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { Box, Typography, IconButton, Theme } from "@mui/material";
-import { SnackbarKey, useSnackbar } from "notistack";
+import { toast } from "sonner";
 
 export type SnackbarVariant =
   | "success"
@@ -16,7 +16,7 @@ export type SnackbarVariant =
   | "default";
 
 interface NotificationContentProps {
-  id: SnackbarKey;
+  id: string | number;
   message: string;
   variant: SnackbarVariant;
   title?: string;
@@ -53,7 +53,7 @@ export const NotificationContent = forwardRef<
   HTMLDivElement,
   NotificationContentProps
 >(({ id, message, variant, title }, ref) => {
-  const { closeSnackbar } = useSnackbar();
+  const closeSnackbar = (key: string | number) => toast.dismiss(key);
   const DynamicIcon = variantIcons[variant];
   const iconColor = "#fff";
 

--- a/ui/frontend-lib/src/common/hooks/index.ts
+++ b/ui/frontend-lib/src/common/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useEntityMetadata";
 export * from "./useFilterState";
 export * from "./useHashParams";
+export * from "./useNotification";

--- a/ui/frontend-lib/src/common/hooks/useNotification.tsx
+++ b/ui/frontend-lib/src/common/hooks/useNotification.tsx
@@ -1,21 +1,11 @@
-import { enqueueSnackbar, SnackbarKey } from "notistack";
+import { toast } from "sonner";
 
 import { ApiClientError } from "../../errors";
-import {
-  SnackbarVariant,
-  NotificationContent,
-  DependencyError,
-} from "../components/notifications";
+import { SnackbarVariant, DependencyError } from "../components/notifications";
 import { ErrorWithStatusCode } from "../components/notifications/ErrorWithStatusCode";
 
 interface NotifyOptions {
-  persist?: boolean;
-  autoHideDuration?: number | null;
-  anchorOrigin?: {
-    vertical: "top" | "bottom";
-    horizontal: "left" | "center" | "right";
-  };
-  preventDuplicate?: boolean;
+  duration?: number;
 }
 
 function getMessage(message: any) {
@@ -26,74 +16,80 @@ function getMessage(message: any) {
   }
 }
 
+const toastForVariant = (variant: SnackbarVariant) => {
+  switch (variant) {
+    case "success":
+      return toast.success;
+    case "error":
+      return toast.error;
+    case "warning":
+      return toast.warning;
+    case "info":
+      return toast.info;
+    default:
+      return toast;
+  }
+};
+
 export const notify = (
   message: any,
   variant: SnackbarVariant,
   options?: NotifyOptions,
 ) => {
-  enqueueSnackbar(message, {
-    variant: variant,
-    autoHideDuration: 5000,
-    anchorOrigin: { vertical: "top", horizontal: "right" },
-    ...options,
-
-    content: (snackbarKey: SnackbarKey) => (
-      <NotificationContent
-        id={snackbarKey}
-        message={message}
-        variant={variant}
-      />
-    ),
+  const messageStr =
+    typeof message === "string" ? message : getMessage(message);
+  toastForVariant(variant)(messageStr, {
+    duration: options?.duration ?? 5000,
+    toasterId: "global",
   });
 };
 
 export const notifyError = (error: unknown, options?: NotifyOptions) => {
-  let displayMessage: string;
-
   if (error instanceof ApiClientError) {
-    displayMessage = `${error.status} ${getMessage(error.message)}`;
+    const displayMessage = `${error.status} ${getMessage(error.message)}`;
+
     if (error.error_code === "DEPENDENCY_ERROR") {
-      enqueueSnackbar(displayMessage, {
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "right",
-        },
-        persist: true,
-        ...options,
-        content: (key) => (
+      toast.custom(
+        (id) => (
           <DependencyError
-            id={key}
+            id={id}
             message={displayMessage}
             metadata={error.metadata}
           />
         ),
-      });
-    } else if (
+        { duration: Infinity, toasterId: "errors" },
+      );
+      return;
+    }
+
+    if (
       error.error_code &&
       error.error_code.toUpperCase() !== "UNKNOWN_ERROR"
     ) {
-      enqueueSnackbar(displayMessage, {
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "right",
-        },
-        persist: true,
-        ...options,
-        content: (key) => (
+      toast.custom(
+        (id) => (
           <ErrorWithStatusCode
-            id={key}
+            id={id}
             message={displayMessage}
             metadata={error.metadata}
           />
         ),
-      });
-    } else {
-      notify(displayMessage, "error", options);
+        { duration: Infinity, toasterId: "errors" },
+      );
+      return;
     }
-  } else if (error instanceof Error) {
-    notify(`${error.message}`, "error", options);
-  } else {
-    displayMessage = `Request failed due to an unknown error.`;
-    notify(displayMessage, "error", options);
+
+    toast.error(displayMessage, { toasterId: "errors", ...options });
+    return;
   }
+
+  if (error instanceof Error) {
+    toast.error(error.message, { toasterId: "errors", ...options });
+    return;
+  }
+
+  toast.error("Request failed due to an unknown error.", {
+    toasterId: "errors",
+    ...options,
+  });
 };

--- a/ui/frontend-lib/src/common/wrappers/RouterSnackbarWrapper.tsx
+++ b/ui/frontend-lib/src/common/wrappers/RouterSnackbarWrapper.tsx
@@ -1,11 +1,35 @@
 import { Outlet } from "react-router";
 
-import { SnackbarProvider } from "notistack";
+import { useColorScheme } from "@mui/material/styles";
+import { Toaster } from "sonner";
 
 export const RouterSnackbarWrapper = () => {
+  const { mode } = useColorScheme();
   return (
-    <SnackbarProvider maxSnack={5} preventDuplicate>
+    <>
+      <Toaster
+        id="global"
+        position="top-right"
+        richColors
+        closeButton
+        theme={mode ?? "system"}
+        visibleToasts={5}
+        style={{ ["--width" as any]: "520px" }}
+        toastOptions={{
+          style: { fontSize: "0.95rem", padding: "16px" },
+        }}
+      />
+      <Toaster
+        id="errors"
+        position="bottom-right"
+        theme={mode ?? "system"}
+        visibleToasts={3}
+        style={{ ["--width" as any]: "520px" }}
+        toastOptions={{
+          style: { fontSize: "0.95rem", padding: "16px" },
+        }}
+      />
       <Outlet />
-    </SnackbarProvider>
+    </>
   );
 };

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -498,7 +498,6 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.2.0"
     eslint-plugin-unused-imports: "npm:^4.4.1"
     moment: "npm:^2.30.1"
-    notistack: "npm:^3.0.2"
     prettier: "npm:~3.6.2"
     query-string: "npm:^9.3.1"
     react: "npm:^19.2.5"
@@ -508,6 +507,7 @@ __metadata:
     react-infinite-scroll-component: "npm:^6.1.1"
     react-router: "npm:^7.14.1"
     react-use: "npm:^17.6.0"
+    sonner: "npm:^2.0.7"
     typescript: "npm:^5.9.3"
     vite: "npm:^7.3.2"
     vite-plugin-dts: "npm:^4.5.4"
@@ -2806,13 +2806,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.1.0":
-  version: 1.2.1
-  resolution: "clsx@npm:1.2.1"
-  checksum: 10/5ded6f61f15f1fa0350e691ccec43a28b12fb8e64c8e94715f2a937bc3722d4c3ed41d6e945c971fc4dcc2a7213a43323beaf2e1c28654af63ba70c9968a8643
-  languageName: node
-  linkType: hard
-
 "clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
@@ -4022,15 +4015,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"goober@npm:^2.0.33":
-  version: 2.1.18
-  resolution: "goober@npm:2.1.18"
-  peerDependencies:
-    csstype: ^3.0.10
-  checksum: 10/eca3db81a709a03f6ec9bb2624027e157c0b6fab6dccbe53b2ddd25a155a7e6e23a0b864574c33bdb0a05e0d0b865de8cc5151401e5a00d63f51be08fe7ccde6
-  languageName: node
-  linkType: hard
-
 "gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -5149,19 +5133,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"notistack@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "notistack@npm:3.0.2"
-  dependencies:
-    clsx: "npm:^1.1.0"
-    goober: "npm:^2.0.33"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/aa27fd7de830d0424c6a7b7966e00dee1e4a2a6894e30b17ead09c2f0f6fd51b96a6bc127985e8cc6d1c2b2d46461706f8cc33ad507dfd64a5058f2c73077d9e
-  languageName: node
-  linkType: hard
-
 "object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
@@ -6092,6 +6063,16 @@ __metadata:
     ip-address: "npm:^10.0.1"
     smart-buffer: "npm:^4.2.0"
   checksum: 10/d19366c95908c19db154f329bbe94c2317d315dc933a7c2b5101e73f32a555c84fb199b62174e1490082a593a4933d8d5a9b297bde7d1419c14a11a965f51356
+  languageName: node
+  linkType: hard
+
+"sonner@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "sonner@npm:2.0.7"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10/c80321646f7fe06f92f4c16da9d72a27aec34abbf41438f8d8e8292ba8546d6bb620c54a113928f049948db1ad29d0b2ad3e9cb29dd5802c30951b41c99f12c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updated notifications package from `notistack` to `sonner`, since the later one supports automatic stacking which solves the problem of too many notifications blocking the user's view of the page. 

Multiple notifications, stacked
<img width="503" height="149" alt="image" src="https://github.com/user-attachments/assets/298bc74e-6e26-4d1b-a3dd-6ab3a272a099" />

Multiple notifications, open
<img width="542" height="496" alt="image" src="https://github.com/user-attachments/assets/502eec8a-a9c0-4fc3-b876-6e376d1c165d" />

Multiple error notifications, stacked
<img width="1720" height="1244" alt="image" src="https://github.com/user-attachments/assets/8ff4deeb-a934-41c3-b7be-a4f3b15ed7a8" />

Multiple error notifications, open
<img width="719" height="854" alt="image" src="https://github.com/user-attachments/assets/55a852e1-b44f-4a10-b896-a7cc8700cdd7" />

Full view:
<img width="2519" height="1319" alt="image" src="https://github.com/user-attachments/assets/361ce408-0d22-4948-88f7-8f2a508227b1" />
