### PR TITLE
Update notifications from WS to be more descriptive

### DIFF
--- a/server/src/application/workers/task_worker.py
+++ b/server/src/application/workers/task_worker.py
@@ -108,7 +108,7 @@ class TaskWorker(BaseMessagesWorker):
             prometheus_counter.labels(entity_controller, "success").inc()
         except Exception as e:
             prometheus_counter.labels(entity_controller, "error").inc()
-            await self.handle_exception(e, message, task_controller)
+            await self.handle_exception(e, message, task_controller, action)
 
     async def process_scheduler_job(self, msg: MessageModel):
         job_id = msg.body.get("job_id")
@@ -194,7 +194,7 @@ class TaskWorker(BaseMessagesWorker):
             case _:
                 raise CannotProceed(f"Unknown entity controller: {entity_controller}")
 
-    async def handle_is_not_ready_exception(self, e, message, task_controller):
+    async def handle_is_not_ready_exception(self, e, message, task_controller, action=None):
         message.max_retries = 3
         message.delay = 1000 * 1
         task_controller.logger.warning(f"{message.retries}/{message.max_retries} {e}")
@@ -202,83 +202,126 @@ class TaskWorker(BaseMessagesWorker):
             task_controller.logger.error("Task is timed out")
             await task_controller.make_failed()
             await task_controller.logger.save_log()
+            entity_name = task_controller.logger.entity_name
+            entity_label = entity_name.replace("_", " ").capitalize()
             await self.send_task_notification(
-                task_controller, f"Task failed for {task_controller.logger.entity_id}: Task is timed out"
+                task_controller,
+                f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
+                title=f"{entity_label} {action or 'task'} timed out".strip(),
+                action=action,
             )
             raise TaskFailure from e
         await task_controller.make_retry(message.retries, message.max_retries)
         await task_controller.logger.save_log()
         await self.on_failure(message)
 
-    async def handle_is_not_right_state_exception(self, e, message, task_controller):
+    async def handle_is_not_right_state_exception(self, e, message, task_controller, action=None):
         message.max_retries = 3
         message.delay = 1000 * 1
         if message.retries >= message.max_retries:
             task_controller.logger.error("Task is timed out")
             await task_controller.make_failed()
             await task_controller.logger.save_log()
+            entity_name = task_controller.logger.entity_name
+            entity_label = entity_name.replace("_", " ").capitalize()
             await self.send_task_notification(
-                task_controller, f"Task failed for {task_controller.logger.entity_id}: Task is timed out"
+                task_controller,
+                f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
+                title=f"{entity_label} {action or 'task'} timed out".strip(),
+                action=action,
             )
             raise TaskFailure from e
         await task_controller.logger.save_log()
         await self.on_failure(message)
 
-    async def handle_generic_exception(self, e, task_controller, error_type):
+    async def handle_generic_exception(self, e, task_controller, error_type, action=None):
         task_controller.logger.error(f"{error_type}: {e}")
         await task_controller.make_failed()
         await task_controller.logger.save_log()
+        entity_name = task_controller.logger.entity_name
+        entity_label = entity_name.replace("_", " ").capitalize()
         await self.send_task_notification(
-            task_controller, f"Task failed for {task_controller.logger.entity_id}: {error_type}"
+            task_controller,
+            f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_type}".strip(),
+            title=f"{entity_label} {action or 'task'} failed".strip(),
+            action=action,
         )
         raise TaskFailure from e
 
-    async def handle_exit_without_state_exception(self, e, task_controller):
+    async def handle_exit_without_state_exception(self, e, task_controller, action=None):
         error_message = f"ExitWithoutSave: {e}"
         task_controller.logger.error(error_message)
         await task_controller.logger.save_log()
+        entity_name = task_controller.logger.entity_name
+        entity_label = entity_name.replace("_", " ").capitalize()
         await self.send_task_notification(
-            task_controller, f"Task failed for {task_controller.logger.entity_id}: {error_message}"
+            task_controller,
+            f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
+            title=f"{entity_label} {action or 'task'} failed".strip(),
+            action=action,
         )
         raise TaskFailure from e
 
-    async def handle_unexpected_exception(self, e, task_controller):
+    async def handle_unexpected_exception(self, e, task_controller, action=None):
         task_controller.logger.error("Unhandled exception occurred")
         await task_controller.make_failed()
         await task_controller.logger.save_log()
 
         error_message = f"UnhandledException: {e}"
         logger.error(f"Unhandled exception: {e}", exc_info=True)
+        entity_name = task_controller.logger.entity_name
+        entity_label = entity_name.replace("_", " ").capitalize()
         await self.send_task_notification(
-            task_controller, f"Task failed for {task_controller.logger.entity_id}: {error_message}"
+            task_controller,
+            f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
+            title=f"{entity_label} {action or 'task'} failed".strip(),
+            action=action,
         )
         raise TaskFailure from e
 
-    async def send_task_notification(self, task_controller, message: str):
+    async def send_task_notification(
+        self,
+        task_controller,
+        message: str,
+        title: str | None = None,
+        action: str | None = None,
+    ):
         entity_id = task_controller.logger.entity_id
         entity_name = task_controller.logger.entity_name
         user_id = str(task_controller.user.id)
 
         logger.debug(f"Sending notification - entity_id: {entity_id}, entity_name: {entity_name}, user_id: {user_id}")
 
-        notification_message = create_message(body={"msg": message}, entity_name=entity_name, user_id=user_id)
+        notification_message = create_message(
+            body={
+                "msg": message,
+                "title": title,
+                "action": action,
+                "entity_id": str(entity_id) if entity_id is not None else None,
+                "entity_name": entity_name,
+            },
+            entity_name=entity_name,
+            user_id=user_id,
+        )
         await send_message(notification_message)
         logger.debug(f"Notification sent: {notification_message}")
 
     async def _send_success_notification(self, task_controller, action):
-        notification_message = f"Task {action} for {task_controller.logger.entity_name} completed successfully."
-        await self.send_task_notification(task_controller, notification_message)
+        entity_name = task_controller.logger.entity_name
+        title = f"{entity_name.replace('_', ' ').capitalize()} {action} succeeded"
+        notification_message = f"Task {action} for {entity_name} completed successfully."
+        await self.send_task_notification(task_controller, notification_message, title=title, action=action)
 
-    async def handle_exception(self, e, message, task_controller):
+    async def handle_exception(self, e, message, task_controller, action=None):
         if isinstance(e, ParentIsNotReady) or isinstance(e, ChildrenIsNotReady):
-            await self.handle_is_not_ready_exception(e, message, task_controller)
+            await self.handle_is_not_ready_exception(e, message, task_controller, action=action)
         elif isinstance(e, EntityWrongState):
-            await self.handle_is_not_right_state_exception(e, message, task_controller)
+            await self.handle_is_not_right_state_exception(e, message, task_controller, action=action)
         elif isinstance(e, CannotProceed):
-            await self.handle_generic_exception(e, task_controller, "CannotProceed")
+            await self.handle_generic_exception(e, task_controller, "CannotProceed", action=action)
         elif isinstance(e, ExitWithoutSave):
-            await self.handle_exit_without_state_exception(e, task_controller)
+            await self.handle_exit_without_state_exception(e, task_controller, action=action)
         elif isinstance(e, AssertionError):
-            await self.handle_generic_exception(e, task_controller, "AssertionError")
+            await self.handle_generic_exception(e, task_controller, "AssertionError", action=action)
         else:
-            await self.handle_unexpected_exception(e, task_controller)
+            await self.handle_unexpected_exception(e, task_controller, action=action)

--- a/server/src/application/workers/task_worker.py
+++ b/server/src/application/workers/task_worker.py
@@ -208,7 +208,6 @@ class TaskWorker(BaseMessagesWorker):
                 task_controller,
                 f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
                 title=f"{entity_label} {action or 'task'} timed out".strip(),
-                action=action,
             )
             raise TaskFailure from e
         await task_controller.make_retry(message.retries, message.max_retries)
@@ -228,7 +227,6 @@ class TaskWorker(BaseMessagesWorker):
                 task_controller,
                 f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
                 title=f"{entity_label} {action or 'task'} timed out".strip(),
-                action=action,
             )
             raise TaskFailure from e
         await task_controller.logger.save_log()
@@ -244,7 +242,6 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_type}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
-            action=action,
         )
         raise TaskFailure from e
 
@@ -258,7 +255,6 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
-            action=action,
         )
         raise TaskFailure from e
 
@@ -275,7 +271,6 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
-            action=action,
         )
         raise TaskFailure from e
 
@@ -284,7 +279,6 @@ class TaskWorker(BaseMessagesWorker):
         task_controller,
         message: str,
         title: str | None = None,
-        action: str | None = None,
     ):
         entity_id = task_controller.logger.entity_id
         entity_name = task_controller.logger.entity_name
@@ -296,7 +290,6 @@ class TaskWorker(BaseMessagesWorker):
             body={
                 "msg": message,
                 "title": title,
-                "action": action,
                 "entity_id": str(entity_id) if entity_id is not None else None,
                 "entity_name": entity_name,
             },
@@ -310,7 +303,7 @@ class TaskWorker(BaseMessagesWorker):
         entity_name = task_controller.logger.entity_name
         title = f"{entity_name.replace('_', ' ').capitalize()} {action} succeeded"
         notification_message = f"Task {action} for {entity_name} completed successfully."
-        await self.send_task_notification(task_controller, notification_message, title=title, action=action)
+        await self.send_task_notification(task_controller, notification_message, title=title)
 
     async def handle_exception(self, e, message, task_controller, action=None):
         if isinstance(e, ParentIsNotReady) or isinstance(e, ChildrenIsNotReady):

--- a/server/src/application/workers/task_worker.py
+++ b/server/src/application/workers/task_worker.py
@@ -208,6 +208,7 @@ class TaskWorker(BaseMessagesWorker):
                 task_controller,
                 f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
                 title=f"{entity_label} {action or 'task'} timed out".strip(),
+                status="error",
             )
             raise TaskFailure from e
         await task_controller.make_retry(message.retries, message.max_retries)
@@ -227,6 +228,7 @@ class TaskWorker(BaseMessagesWorker):
                 task_controller,
                 f"Task {action or ''} failed for {task_controller.logger.entity_id}: Task is timed out".strip(),
                 title=f"{entity_label} {action or 'task'} timed out".strip(),
+                status="error",
             )
             raise TaskFailure from e
         await task_controller.logger.save_log()
@@ -242,6 +244,7 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_type}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
+            status="error",
         )
         raise TaskFailure from e
 
@@ -255,6 +258,7 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
+            status="error",
         )
         raise TaskFailure from e
 
@@ -271,6 +275,7 @@ class TaskWorker(BaseMessagesWorker):
             task_controller,
             f"Task {action or ''} failed for {task_controller.logger.entity_id}: {error_message}".strip(),
             title=f"{entity_label} {action or 'task'} failed".strip(),
+            status="error",
         )
         raise TaskFailure from e
 
@@ -279,6 +284,7 @@ class TaskWorker(BaseMessagesWorker):
         task_controller,
         message: str,
         title: str | None = None,
+        status: str = "info",
     ):
         entity_id = task_controller.logger.entity_id
         entity_name = task_controller.logger.entity_name
@@ -290,6 +296,7 @@ class TaskWorker(BaseMessagesWorker):
             body={
                 "msg": message,
                 "title": title,
+                "status": status,
                 "entity_id": str(entity_id) if entity_id is not None else None,
                 "entity_name": entity_name,
             },
@@ -303,7 +310,7 @@ class TaskWorker(BaseMessagesWorker):
         entity_name = task_controller.logger.entity_name
         title = f"{entity_name.replace('_', ' ').capitalize()} {action} succeeded"
         notification_message = f"Task {action} for {entity_name} completed successfully."
-        await self.send_task_notification(task_controller, notification_message, title=title)
+        await self.send_task_notification(task_controller, notification_message, title=title, status="success")
 
     async def handle_exception(self, e, message, task_controller, action=None):
         if isinstance(e, ParentIsNotReady) or isinstance(e, ChildrenIsNotReady):

--- a/server/tests/application/workers/test_task_worker.py
+++ b/server/tests/application/workers/test_task_worker.py
@@ -266,7 +266,6 @@ class TestTaskWorker:
             body={
                 "msg": test_message,
                 "title": None,
-                "action": None,
                 "entity_id": "test_entity_123",
                 "entity_name": "test_source_code",
             },
@@ -296,7 +295,6 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "My deployment deploy succeeded",
-                "action": "deploy",
                 "entity_id": "entity_789",
                 "entity_name": "my_deployment",
             },
@@ -326,7 +324,6 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Failed resource task failed",
-                "action": None,
                 "entity_id": "failed_entity_123",
                 "entity_name": "failed_resource",
             },
@@ -365,7 +362,6 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Timeout storage task timed out",
-                "action": None,
                 "entity_id": "timeout_entity_456",
                 "entity_name": "timeout_storage",
             },
@@ -397,7 +393,6 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Exit workspace task failed",
-                "action": None,
                 "entity_id": "exit_entity_789",
                 "entity_name": "exit_workspace",
             },
@@ -428,7 +423,6 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Unexpected resource task failed",
-                "action": None,
                 "entity_id": "unexpected_entity_000",
                 "entity_name": "unexpected_resource",
             },
@@ -467,7 +461,6 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for my_storage",
                 "title": None,
-                "action": None,
                 "entity_id": "storage_entity_123",
                 "entity_name": "my_storage",
             },
@@ -478,7 +471,6 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for dev_workspace",
                 "title": None,
-                "action": None,
                 "entity_id": "workspace_entity_456",
                 "entity_name": "dev_workspace",
             },
@@ -489,7 +481,6 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for api_resource",
                 "title": None,
-                "action": None,
                 "entity_id": "resource_entity_789",
                 "entity_name": "api_resource",
             },

--- a/server/tests/application/workers/test_task_worker.py
+++ b/server/tests/application/workers/test_task_worker.py
@@ -263,7 +263,15 @@ class TestTaskWorker:
         await task_worker.send_task_notification(mock_task_controller, test_message)
 
         mock_create_message.assert_called_once_with(
-            body={"msg": test_message}, entity_name="test_source_code", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": test_message,
+                "title": None,
+                "action": None,
+                "entity_id": "test_entity_123",
+                "entity_name": "test_source_code",
+            },
+            entity_name="test_source_code",
+            user_id=str(mock_task_controller.user.id),
         )
 
         mock_send_message.assert_awaited_once_with("created_notification_message")
@@ -285,7 +293,15 @@ class TestTaskWorker:
 
         expected_message = "Task deploy for my_deployment completed successfully."
         mock_create_message.assert_called_once_with(
-            body={"msg": expected_message}, entity_name="my_deployment", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": expected_message,
+                "title": "My deployment deploy succeeded",
+                "action": "deploy",
+                "entity_id": "entity_789",
+                "entity_name": "my_deployment",
+            },
+            entity_name="my_deployment",
+            user_id=str(mock_task_controller.user.id),
         )
 
     @pytest.mark.asyncio
@@ -305,9 +321,17 @@ class TestTaskWorker:
         with pytest.raises(tw_mod.TaskFailure):
             await task_worker.handle_generic_exception(test_exception, mock_task_controller, "CannotProceed")
 
-        expected_message = "Task failed for failed_entity_123: CannotProceed"
+        expected_message = "Task  failed for failed_entity_123: CannotProceed"
         mock_create_message.assert_called_once_with(
-            body={"msg": expected_message}, entity_name="failed_resource", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": expected_message,
+                "title": "Failed resource task failed",
+                "action": None,
+                "entity_id": "failed_entity_123",
+                "entity_name": "failed_resource",
+            },
+            entity_name="failed_resource",
+            user_id=str(mock_task_controller.user.id),
         )
 
         mock_task_controller.make_failed.assert_awaited_once()
@@ -336,9 +360,17 @@ class TestTaskWorker:
         with pytest.raises(tw_mod.TaskFailure):
             await task_worker.handle_is_not_ready_exception(test_exception, mock_message, mock_task_controller)
 
-        expected_message = "Task failed for timeout_entity_456: Task is timed out"
+        expected_message = "Task  failed for timeout_entity_456: Task is timed out"
         mock_create_message.assert_called_once_with(
-            body={"msg": expected_message}, entity_name="timeout_storage", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": expected_message,
+                "title": "Timeout storage task timed out",
+                "action": None,
+                "entity_id": "timeout_entity_456",
+                "entity_name": "timeout_storage",
+            },
+            entity_name="timeout_storage",
+            user_id=str(mock_task_controller.user.id),
         )
 
     @pytest.mark.asyncio
@@ -360,9 +392,17 @@ class TestTaskWorker:
         with pytest.raises(tw_mod.TaskFailure):
             await task_worker.handle_exit_without_state_exception(test_exception, mock_task_controller)
 
-        expected_message = "Task failed for exit_entity_789: ExitWithoutSave: Exit without saving changes"
+        expected_message = "Task  failed for exit_entity_789: ExitWithoutSave: Exit without saving changes"
         mock_create_message.assert_called_once_with(
-            body={"msg": expected_message}, entity_name="exit_workspace", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": expected_message,
+                "title": "Exit workspace task failed",
+                "action": None,
+                "entity_id": "exit_entity_789",
+                "entity_name": "exit_workspace",
+            },
+            entity_name="exit_workspace",
+            user_id=str(mock_task_controller.user.id),
         )
 
     @pytest.mark.asyncio
@@ -383,9 +423,17 @@ class TestTaskWorker:
         with pytest.raises(tw_mod.TaskFailure):
             await task_worker.handle_unexpected_exception(test_exception, mock_task_controller)
 
-        expected_message = "Task failed for unexpected_entity_000: UnhandledException: Unexpected runtime error"
+        expected_message = "Task  failed for unexpected_entity_000: UnhandledException: Unexpected runtime error"
         mock_create_message.assert_called_once_with(
-            body={"msg": expected_message}, entity_name="unexpected_resource", user_id=str(mock_task_controller.user.id)
+            body={
+                "msg": expected_message,
+                "title": "Unexpected resource task failed",
+                "action": None,
+                "entity_id": "unexpected_entity_000",
+                "entity_name": "unexpected_resource",
+            },
+            entity_name="unexpected_resource",
+            user_id=str(mock_task_controller.user.id),
         )
 
     @pytest.mark.asyncio
@@ -416,11 +464,35 @@ class TestTaskWorker:
 
         user_id_str = str(mocked_user.id)
         mock_create_message.assert_any_call(
-            body={"msg": "Test message for my_storage"}, entity_name="my_storage", user_id=user_id_str
+            body={
+                "msg": "Test message for my_storage",
+                "title": None,
+                "action": None,
+                "entity_id": "storage_entity_123",
+                "entity_name": "my_storage",
+            },
+            entity_name="my_storage",
+            user_id=user_id_str,
         )
         mock_create_message.assert_any_call(
-            body={"msg": "Test message for dev_workspace"}, entity_name="dev_workspace", user_id=user_id_str
+            body={
+                "msg": "Test message for dev_workspace",
+                "title": None,
+                "action": None,
+                "entity_id": "workspace_entity_456",
+                "entity_name": "dev_workspace",
+            },
+            entity_name="dev_workspace",
+            user_id=user_id_str,
         )
         mock_create_message.assert_any_call(
-            body={"msg": "Test message for api_resource"}, entity_name="api_resource", user_id=user_id_str
+            body={
+                "msg": "Test message for api_resource",
+                "title": None,
+                "action": None,
+                "entity_id": "resource_entity_789",
+                "entity_name": "api_resource",
+            },
+            entity_name="api_resource",
+            user_id=user_id_str,
         )

--- a/server/tests/application/workers/test_task_worker.py
+++ b/server/tests/application/workers/test_task_worker.py
@@ -266,6 +266,7 @@ class TestTaskWorker:
             body={
                 "msg": test_message,
                 "title": None,
+                "status": "info",
                 "entity_id": "test_entity_123",
                 "entity_name": "test_source_code",
             },
@@ -295,6 +296,7 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "My deployment deploy succeeded",
+                "status": "success",
                 "entity_id": "entity_789",
                 "entity_name": "my_deployment",
             },
@@ -324,6 +326,7 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Failed resource task failed",
+                "status": "error",
                 "entity_id": "failed_entity_123",
                 "entity_name": "failed_resource",
             },
@@ -362,6 +365,7 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Timeout storage task timed out",
+                "status": "error",
                 "entity_id": "timeout_entity_456",
                 "entity_name": "timeout_storage",
             },
@@ -393,6 +397,7 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Exit workspace task failed",
+                "status": "error",
                 "entity_id": "exit_entity_789",
                 "entity_name": "exit_workspace",
             },
@@ -423,6 +428,7 @@ class TestTaskWorker:
             body={
                 "msg": expected_message,
                 "title": "Unexpected resource task failed",
+                "status": "error",
                 "entity_id": "unexpected_entity_000",
                 "entity_name": "unexpected_resource",
             },
@@ -461,6 +467,7 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for my_storage",
                 "title": None,
+                "status": "info",
                 "entity_id": "storage_entity_123",
                 "entity_name": "my_storage",
             },
@@ -471,6 +478,7 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for dev_workspace",
                 "title": None,
+                "status": "info",
                 "entity_id": "workspace_entity_456",
                 "entity_name": "dev_workspace",
             },
@@ -481,6 +489,7 @@ class TestTaskWorker:
             body={
                 "msg": "Test message for api_resource",
                 "title": None,
+                "status": "info",
                 "entity_id": "resource_entity_789",
                 "entity_name": "api_resource",
             },

--- a/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
+++ b/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
@@ -1,10 +1,36 @@
 import { useEffect, useRef } from "react";
 
+import { useConfig } from "../context/ConfigContext";
 import { useNotificationProvider } from "../context/NotificationContext";
 import { notify } from "../hooks/useNotification";
 
+const ENTITY_PATHS: Record<string, string> = {
+  resource: "resources",
+  workspace: "workspaces",
+  storage: "storages",
+  executor: "executors",
+  source_code: "source_codes",
+  secret: "secrets",
+  template: "templates",
+  integration: "integrations",
+  auth_provider: "auth_providers",
+};
+
+const ENTITY_LABELS: Record<string, string> = {
+  resource: "View resource",
+  workspace: "View workspace",
+  storage: "View storage",
+  executor: "View executor",
+  source_code: "View source code",
+  secret: "View secret",
+  template: "View template",
+  integration: "View integration",
+  auth_provider: "View auth provider",
+};
+
 export const GlobalNotificationPopup = () => {
   const { notification } = useNotificationProvider();
+  const { linkPrefix } = useConfig();
   const lastSourceId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -17,6 +43,8 @@ export const GlobalNotificationPopup = () => {
         message: notification.msg,
         type: notification.type || "info",
         title: notification.title,
+        entity_id: notification.entity_id,
+        entity_name: notification.entity_name,
       };
     }
 
@@ -31,16 +59,45 @@ export const GlobalNotificationPopup = () => {
       | "warning"
       | "info";
 
-    const title = notificationData.title;
-    const body =
+    const title: string | undefined = notificationData.title;
+    const body: string =
       notificationData.message ||
       notificationData.msg ||
       "Notification received";
 
-    const finalMessage = title && title !== body ? `${title}: ${body}` : body;
+    const entityName: string | undefined = notificationData.entity_name;
+    const entityId: string | undefined = notificationData.entity_id;
+    const action: string | undefined = notificationData.action;
+    const segment = entityName ? ENTITY_PATHS[entityName] : undefined;
+    const isFailure = severity === "error" || severity === "warning";
+    const link =
+      segment && entityId
+        ? isFailure
+          ? {
+              to: `${linkPrefix}${segment}/${entityId}/logs`,
+              label: "View logs",
+            }
+          : {
+              to: `${linkPrefix}${segment}/${entityId}`,
+              label: action
+                ? `View ${action} ${(entityName ?? "").replace(/_/g, " ")}`.trim()
+                : (ENTITY_LABELS[entityName!] ?? "View"),
+            }
+        : undefined;
 
-    notify(finalMessage, severity, { duration: 8000 });
-  }, [notification]);
+    const headline = title && title.trim() ? title : body;
+    const description =
+      title && title.trim() && title !== body ? body : undefined;
+    const toastId =
+      entityName && entityId ? `entity:${entityName}:${entityId}` : undefined;
+
+    notify(headline, severity, {
+      duration: 8000,
+      link,
+      description,
+      id: toastId,
+    });
+  }, [notification, linkPrefix]);
 
   return null;
 };

--- a/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
+++ b/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
@@ -67,7 +67,6 @@ export const GlobalNotificationPopup = () => {
 
     const entityName: string | undefined = notificationData.entity_name;
     const entityId: string | undefined = notificationData.entity_id;
-    const action: string | undefined = notificationData.action;
     const segment = entityName ? ENTITY_PATHS[entityName] : undefined;
     const isFailure = severity === "error" || severity === "warning";
     const link =
@@ -79,9 +78,7 @@ export const GlobalNotificationPopup = () => {
             }
           : {
               to: `${linkPrefix}${segment}/${entityId}`,
-              label: action
-                ? `View ${action} ${(entityName ?? "").replace(/_/g, " ")}`.trim()
-                : (ENTITY_LABELS[entityName!] ?? "View"),
+              label: ENTITY_LABELS[entityName!] ?? "View",
             }
         : undefined;
 

--- a/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
+++ b/ui/frontend-lib/src/common/components/GlobalNotificationPopup.tsx
@@ -36,50 +36,29 @@ export const GlobalNotificationPopup = () => {
   useEffect(() => {
     if (!notification) return;
 
-    let notificationData: any = notification;
-    if (notification.msg && typeof notification.msg === "string") {
-      notificationData = {
-        id: notification.id || Date.now().toString(),
-        message: notification.msg,
-        type: notification.type || "info",
-        title: notification.title,
-        entity_id: notification.entity_id,
-        entity_name: notification.entity_name,
-      };
-    }
-
-    const sourceId = notificationData.id || Date.now().toString();
+    const sourceId = notification.id || Date.now().toString();
     if (sourceId === lastSourceId.current) return; // simple dedupe
     lastSourceId.current = sourceId;
 
-    const severity = (notificationData.type || "info") as
+    const severity = (notification.status || "info") as
       | "default"
       | "error"
       | "success"
       | "warning"
       | "info";
 
-    const title: string | undefined = notificationData.title;
-    const body: string =
-      notificationData.message ||
-      notificationData.msg ||
-      "Notification received";
+    const title: string | undefined = notification.title;
+    const body: string = notification.msg || "Notification received";
 
-    const entityName: string | undefined = notificationData.entity_name;
-    const entityId: string | undefined = notificationData.entity_id;
+    const entityName: string | undefined = notification.entity_name;
+    const entityId: string | undefined = notification.entity_id;
     const segment = entityName ? ENTITY_PATHS[entityName] : undefined;
-    const isFailure = severity === "error" || severity === "warning";
     const link =
       segment && entityId
-        ? isFailure
-          ? {
-              to: `${linkPrefix}${segment}/${entityId}/logs`,
-              label: "View logs",
-            }
-          : {
-              to: `${linkPrefix}${segment}/${entityId}`,
-              label: ENTITY_LABELS[entityName!] ?? "View",
-            }
+        ? {
+            to: `${linkPrefix}${segment}/${entityId}`,
+            label: ENTITY_LABELS[entityName!] ?? "View",
+          }
         : undefined;
 
     const headline = title && title.trim() ? title : body;

--- a/ui/frontend-lib/src/common/hooks/useNotification.tsx
+++ b/ui/frontend-lib/src/common/hooks/useNotification.tsx
@@ -1,11 +1,21 @@
+import { Link } from "react-router";
+
 import { toast } from "sonner";
 
 import { ApiClientError } from "../../errors";
 import { SnackbarVariant, DependencyError } from "../components/notifications";
 import { ErrorWithStatusCode } from "../components/notifications/ErrorWithStatusCode";
 
+interface NotifyLink {
+  to: string;
+  label?: string;
+}
+
 interface NotifyOptions {
   duration?: number;
+  link?: NotifyLink;
+  description?: string;
+  id?: string | number;
 }
 
 function getMessage(message: any) {
@@ -38,9 +48,31 @@ export const notify = (
 ) => {
   const messageStr =
     typeof message === "string" ? message : getMessage(message);
+  const action = options?.link ? (
+    <Link
+      to={options.link.to}
+      style={{
+        padding: "4px 8px",
+        borderRadius: 4,
+        fontWeight: 600,
+        fontSize: "0.85rem",
+        textDecoration: "underline",
+        color: "inherit",
+        backgroundColor: "transparent",
+        whiteSpace: "nowrap",
+        marginLeft: "auto",
+      }}
+      onClick={() => toast.dismiss()}
+    >
+      {options.link.label ?? "View"}
+    </Link>
+  ) : undefined;
   toastForVariant(variant)(messageStr, {
     duration: options?.duration ?? 5000,
     toasterId: "global",
+    action,
+    description: options?.description,
+    id: options?.id,
   });
 };
 


### PR DESCRIPTION
This PR
- Updates backend task worker to send more information on task success/fail
- Adds a link to affected entity in information notifications about backend events

<img width="510" height="98" alt="Screenshot 2026-05-04 132140" src="https://github.com/user-attachments/assets/474d6727-0183-4880-8c90-556a99c7f3fb" />
<img width="506" height="151" alt="Screenshot 2026-05-04 130937" src="https://github.com/user-attachments/assets/41b98c6a-7277-47a5-ada4-81a61098dfe2" />
<img width="532" height="133" alt="Screenshot 2026-05-04 130220" src="https://github.com/user-attachments/assets/eb1359a8-a3f3-4074-9582-8dead47314cf" />
<img width="510" height="99" alt="Screenshot 2026-05-04 130923" src="https://github.com/user-attachments/assets/d11113c8-c367-485c-b23a-27c8a3b39cbb" />

