### PR TITLE
stateless mcp since mcp is stateless

### DIFF
--- a/server/src/infrakitchen_mcp/server.py
+++ b/server/src/infrakitchen_mcp/server.py
@@ -62,7 +62,7 @@ def setup_mcp_server(fastapi_app: FastAPI, mount_path: str = "/api/mcp") -> Star
 
     register_docs(mcp_server, DEFAULT_DOCS_DIR)
 
-    mcp_http_app = mcp_server.http_app(path="/")
+    mcp_http_app = mcp_server.http_app(path="/", stateless_http=True)
     mcp_http_app.add_middleware(BaseHTTPMiddleware, dispatch=_auth_middleware_dispatch)
     fastapi_app.mount(mount_path, mcp_http_app)
 


### PR DESCRIPTION
the mcp server is stateless by nature for now. There is no mechanism yet to support statefull mcp with multiple replica deployments so changing to stateless