### PR TITLE
Integrations permission control

### DIFF
--- a/server/src/application/integrations/api.py
+++ b/server/src/application/integrations/api.py
@@ -49,20 +49,16 @@ async def get_by_id(integration_id: str, service: IntegrationService = Depends(g
 @mcp_group(list_entities_group, "integrations")
 async def get_all(
     response: Response,
-    workspace_id: str | None = None,
     service: IntegrationService = Depends(get_integration_service),
     query_parts: QueryParamsType = Depends(parse_query_params),
 ):
     filter, range_, sort, _ = query_parts
-    if workspace_id is not None:
-        result = list(await service.get_all(workspace_id=workspace_id))
-        total = len(result)
+    total = await service.count(filter=filter)
+
+    if total == 0:
+        result = []
     else:
-        total = await service.count(filter=filter)
-        if total == 0:
-            result = []
-        else:
-            result = list(await service.get_all(filter=filter, range=range_, sort=sort))
+        result = list(await service.get_all(filter=filter, range=range_, sort=sort))
     headers = {"Content-Range": f"integrations 0-{len(result)}/{total}"}
     response.headers.update(headers)
     return result

--- a/server/src/application/integrations/api.py
+++ b/server/src/application/integrations/api.py
@@ -4,7 +4,10 @@ from fastapi import status as http_status
 from application.integrations.service import IntegrationService
 from core.base_models import PatchBodyModel
 from core.constants.model import ModelActions
-from core.users.functions import user_has_access_to_api
+from core.permissions.dependencies import get_permission_service
+from core.permissions.schema import EntityPolicyCreate, PermissionResponse
+from core.permissions.service import PermissionService
+from core.users.functions import user_entity_permissions, user_has_access_to_api, user_has_access_to_entity
 from core.users.model import UserDTO
 from core.utils.fastapi_tools import QueryParamsType, parse_query_params
 from infrakitchen_mcp.dispatch_framework import get_one_group, list_entities_group
@@ -16,6 +19,8 @@ from .schema import (
     IntegrationUpdate,
     IntegrationValidationResponse,
     IntegrationValidationRequest,
+    RoleIntegrationsResponse,
+    UserIntegrationResponse,
 )
 
 router = APIRouter()
@@ -44,16 +49,20 @@ async def get_by_id(integration_id: str, service: IntegrationService = Depends(g
 @mcp_group(list_entities_group, "integrations")
 async def get_all(
     response: Response,
+    workspace_id: str | None = None,
     service: IntegrationService = Depends(get_integration_service),
     query_parts: QueryParamsType = Depends(parse_query_params),
 ):
     filter, range_, sort, _ = query_parts
-    total = await service.count(filter=filter)
-
-    if total == 0:
-        result = []
+    if workspace_id is not None:
+        result = list(await service.get_all(workspace_id=workspace_id))
+        total = len(result)
     else:
-        result = list(await service.get_all(filter=filter, range=range_, sort=sort))
+        total = await service.count(filter=filter)
+        if total == 0:
+            result = []
+        else:
+            result = list(await service.get_all(filter=filter, range=range_, sort=sort))
     headers = {"Content-Range": f"integrations 0-{len(result)}/{total}"}
     response.headers.update(headers)
     return result
@@ -161,7 +170,7 @@ async def validate(
     request: Request, integration_id: str, service: IntegrationService = Depends(get_integration_service)
 ):
     requester: UserDTO = request.state.user
-    if not await user_has_access_to_api(requester, "integration", action="write"):
+    if not await user_has_access_to_entity(requester, integration_id, action="write", entity_name="integration"):
         raise HTTPException(status_code=403, detail="Access denied")
 
     integration = await service.get_by_id(integration_id=integration_id)
@@ -170,3 +179,61 @@ async def validate(
     return await service.validate(
         integration_config=integration.configuration, integration_provider=integration.integration_provider
     )
+
+
+# Permissions
+@router.get(
+    "/integrations/permissions/user/{user_id}/policies",
+    response_model=list[UserIntegrationResponse],
+    response_description="Get user integration policies",
+    status_code=http_status.HTTP_200_OK,
+)
+async def get_user_integrations(user_id: str, service: IntegrationService = Depends(get_integration_service)):
+    return await service.get_user_integration_policies(user_id)
+
+
+@router.get(
+    "/integrations/permissions/role/{role_name}/policies",
+    response_model=list[RoleIntegrationsResponse],
+    response_description="Get role policies",
+    status_code=http_status.HTTP_200_OK,
+)
+async def get_integration_role_permissions(
+    response: Response,
+    role_name: str,
+    service: IntegrationService = Depends(get_integration_service),
+    permission_service: PermissionService = Depends(get_permission_service),
+    query_parts: QueryParamsType = Depends(parse_query_params),
+):
+    _, range_, sort, _ = query_parts
+
+    total = await permission_service.count(filter={"v0": role_name, "ptype": "p", "v1__like": "integration:"})
+
+    if total == 0:
+        result = []
+    else:
+        result = await service.get_role_permissions(role_name, range=range_, sort=sort)
+    headers = {"Content-Range": f"policies 0-{len(result)}/{total}"}
+    response.headers.update(headers)
+
+    return result
+
+
+@router.post(
+    "/integrations/permissions",
+    response_model=list[PermissionResponse],
+    response_description="Create integration policy",
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def create_role_integration_permissions(
+    request: Request,
+    integration_policy: EntityPolicyCreate,
+    service: IntegrationService = Depends(get_integration_service),
+):
+    requester: UserDTO = request.state.user
+
+    requester_permissions = await user_entity_permissions(requester, integration_policy.entity_id, "integration")
+    if "admin" not in requester_permissions:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    return await service.create_integration_policy(integration_policy, requester=requester)

--- a/server/src/application/integrations/crud.py
+++ b/server/src/application/integrations/crud.py
@@ -1,7 +1,7 @@
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, literal, select
+from sqlalchemy import String, cast, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import union_all
 
@@ -9,6 +9,8 @@ from application.executors.model import Executor
 from application.resources.model import Resource
 from application.source_codes.model import SourceCode
 from application.storages.model import Storage
+from application.workspaces.model import Workspace
+from core.permissions.model import Permission
 from core.users.model import User
 
 from core.database import evaluate_sqlalchemy_filters, evaluate_sqlalchemy_pagination, evaluate_sqlalchemy_sorting
@@ -93,3 +95,75 @@ class IntegrationCRUD:
 
     async def refresh(self, integration: Integration) -> None:
         await self.session.refresh(integration)
+
+    async def get_by_workspace_id(self, workspace_id: str | UUID) -> list[Integration]:
+        statement = (
+            select(Integration)
+            .join(Workspace, Workspace.integration_id == Integration.id)
+            .where(Workspace.id == workspace_id)
+        )
+        result = await self.session.execute(statement)
+        return list(result.scalars().all())
+
+    async def get_integration_policies_by_role(
+        self,
+        role_name: str,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[Any]:
+        integration_id_expr = func.split_part(Permission.v1, ":", 2)
+        statement = (
+            select(
+                Integration.id.label("integration_id"),
+                Integration.name.label("integration_name"),
+                Permission.v0.label("role"),
+                Permission.v2.label("action"),
+                Permission.id.label("id"),
+                Permission.created_at.label("created_at"),
+                Permission.updated_at.label("updated_at"),
+            )
+            .join(
+                Permission,
+                cast(Integration.id, String) == integration_id_expr,
+            )
+            .where(
+                Permission.ptype == "p",
+                Permission.v1.like("integration:%"),
+                Permission.v0 == role_name,
+            )
+        )
+        statement = evaluate_sqlalchemy_sorting(Permission, statement, sort)
+        statement = evaluate_sqlalchemy_pagination(statement, range)
+        result = await self.session.execute(statement)
+        return list(result.fetchall())
+
+    async def get_user_integration_policies(
+        self,
+        user_id: str | UUID,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[Any]:
+        integration_id_expr = func.split_part(Permission.v1, ":", 2)
+        statement = (
+            select(
+                Integration.id.label("integration_id"),
+                Integration.name.label("integration_name"),
+                Permission.v2.label("action"),
+                Permission.id.label("id"),
+                Permission.created_at.label("created_at"),
+                Permission.updated_at.label("updated_at"),
+            )
+            .join(
+                Permission,
+                cast(Integration.id, String) == integration_id_expr,
+            )
+            .where(
+                Permission.ptype == "p",
+                Permission.v1.like("integration:%"),
+                Permission.v0 == f"user:{user_id}",
+            )
+        )
+        statement = evaluate_sqlalchemy_sorting(Permission, statement, sort)
+        statement = evaluate_sqlalchemy_pagination(statement, range)
+        result = await self.session.execute(statement)
+        return list(result.fetchall())

--- a/server/src/application/integrations/crud.py
+++ b/server/src/application/integrations/crud.py
@@ -9,7 +9,6 @@ from application.executors.model import Executor
 from application.resources.model import Resource
 from application.source_codes.model import SourceCode
 from application.storages.model import Storage
-from application.workspaces.model import Workspace
 from core.permissions.model import Permission
 from core.users.model import User
 
@@ -95,15 +94,6 @@ class IntegrationCRUD:
 
     async def refresh(self, integration: Integration) -> None:
         await self.session.refresh(integration)
-
-    async def get_by_workspace_id(self, workspace_id: str | UUID) -> list[Integration]:
-        statement = (
-            select(Integration)
-            .join(Workspace, Workspace.integration_id == Integration.id)
-            .where(Workspace.id == workspace_id)
-        )
-        result = await self.session.execute(statement)
-        return list(result.scalars().all())
 
     async def get_integration_policies_by_role(
         self,

--- a/server/src/application/integrations/dependencies.py
+++ b/server/src/application/integrations/dependencies.py
@@ -2,6 +2,8 @@ from fastapi import Depends
 
 from core.audit_logs.handler import AuditLogHandler
 from core.dependencies import get_db_session
+from core.permissions.dependencies import get_permission_service
+from core.permissions.service import PermissionService
 from core.revisions.handler import RevisionHandler
 from core.tasks.dependencies import get_task_service
 from core.utils.event_sender import EventSender
@@ -14,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def get_integration_service(
     session: AsyncSession = Depends(get_db_session),
+    permission_service: PermissionService = Depends(get_permission_service),
 ) -> IntegrationService:
     revision_handler = RevisionHandler(session=session, entity_name="integration")
     event_sender = EventSender(entity_name="integration")
@@ -24,4 +27,5 @@ def get_integration_service(
         event_sender=event_sender,
         audit_log_handler=audit_log_handler,
         task_service=get_task_service(session=session),
+        permission_service=permission_service,
     )

--- a/server/src/application/integrations/schema.py
+++ b/server/src/application/integrations/schema.py
@@ -257,3 +257,26 @@ class IntegrationValidationResponse(BaseModel):
     @computed_field
     def _entity_name(self) -> str:
         return "integration_validation_response"
+
+
+class RoleIntegrationsResponse(BaseModel):
+    id: uuid.UUID
+    integration_id: uuid.UUID
+    integration_name: str
+    role: str
+    action: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserIntegrationResponse(BaseModel):
+    id: uuid.UUID
+    integration_id: uuid.UUID
+    integration_name: str
+    action: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/server/src/application/integrations/service.py
+++ b/server/src/application/integrations/service.py
@@ -10,16 +10,25 @@ from core.base_models import PatchBodyModel
 from core.constants import ModelStatus
 from core.constants.model import ModelActions
 from core.database import to_dict
-from core.errors import CloudWrongCredentials, DependencyError, EntityNotFound, EntityWrongState
+from core.errors import CloudWrongCredentials, DependencyError, EntityExistsError, EntityNotFound, EntityWrongState
+from core.permissions.schema import EntityPolicyCreate, PermissionResponse
+from core.permissions.service import PermissionService
 from core.revisions.handler import RevisionHandler
 from core.tasks.service import TaskEntityService
-from core.users.functions import user_api_permission
+from core.users.functions import user_entity_permissions
 from core.users.model import UserDTO
 from core.utils.event_sender import EventSender
 from core.utils.model_tools import model_db_dump
 from .crud import IntegrationCRUD
 from .model import Integration, IntegrationDTO
-from .schema import IntegrationCreate, IntegrationResponse, IntegrationUpdate, IntegrationValidationResponse
+from .schema import (
+    IntegrationCreate,
+    IntegrationResponse,
+    IntegrationUpdate,
+    IntegrationValidationResponse,
+    RoleIntegrationsResponse,
+    UserIntegrationResponse,
+)
 from ..utils.constants import MASKED_VALUE
 
 logger = logging.getLogger(__name__)
@@ -38,12 +47,14 @@ class IntegrationService:
         event_sender: EventSender,
         audit_log_handler: AuditLogHandler,
         task_service: TaskEntityService,
+        permission_service: PermissionService,
     ):
         self.crud: IntegrationCRUD = crud
         self.revision_handler: RevisionHandler = revision_handler
         self.event_sender: EventSender = event_sender
         self.audit_log_handler: AuditLogHandler = audit_log_handler
         self.task_service: TaskEntityService = task_service
+        self.permission_service: PermissionService = permission_service
 
     async def get_dto_by_id(self, integration_id: str | UUID) -> IntegrationDTO | None:
         integration = await self.crud.get_by_id(integration_id)
@@ -57,8 +68,11 @@ class IntegrationService:
             return None
         return IntegrationResponse.model_validate(integration)
 
-    async def get_all(self, **kwargs) -> list[IntegrationResponse]:
-        integrations = await self.crud.get_all(**kwargs)
+    async def get_all(self, workspace_id: str | UUID | None = None, **kwargs) -> list[IntegrationResponse]:
+        if workspace_id is not None:
+            integrations = await self.crud.get_by_workspace_id(workspace_id)
+        else:
+            integrations = await self.crud.get_all(**kwargs)
         return [IntegrationResponse.model_validate(integration) for integration in integrations]
 
     async def get_all_dto(self, **kwargs) -> list[IntegrationDTO]:
@@ -105,6 +119,17 @@ class IntegrationService:
         )
         response = IntegrationResponse.model_validate(result)
         await self.event_sender.send_event(response, ModelActions.CREATE)
+        await self.permission_service.create_entity_policy(
+            EntityPolicyCreate(
+                user_id=requester.id,
+                entity_id=new_integration.id,
+                entity_name="integration",
+                action="admin",
+            ),
+            requester=requester,
+            reload_permission=False,
+        )
+        await self.permission_service.casbin_enforcer.send_reload_event()
         return response
 
     async def update(
@@ -200,6 +225,7 @@ class IntegrationService:
         await self.audit_log_handler.create_log(integration_id, requester.id, ModelActions.DELETE)
         await self.revision_handler.delete_revisions(integration_id)
         await self.task_service.delete_by_entity_id(integration_id)
+        await self.permission_service.delete_entity_permissions("integration", integration_id)
         await self.crud.delete(existing_integration)
 
     async def get_actions(self, integration_id: str, requester: UserDTO) -> list[str]:
@@ -208,11 +234,7 @@ class IntegrationService:
         :param integration_id: ID of the integration
         :return: List of actions
         """
-        apis = await user_api_permission(requester, "integration")
-        if not apis:
-            return []
-        requester_permissions = [apis["api:integration"]]
-
+        requester_permissions = await user_entity_permissions(requester, integration_id, "integration")
         if "write" not in requester_permissions and "admin" not in requester_permissions:
             return []
 
@@ -221,14 +243,15 @@ class IntegrationService:
         if not integration:
             raise EntityNotFound("Integration not found")
 
+        user_is_admin = "admin" in requester_permissions
+
         if integration.status == ModelStatus.ENABLED:
-            if "admin" in requester_permissions:
-                actions.append(ModelActions.EDIT)
-                actions.append(ModelActions.DISABLE)
+            actions.append(ModelActions.EDIT)
+            actions.append(ModelActions.DISABLE)
         if integration.status == ModelStatus.DISABLED:
-            if "admin" in requester_permissions:
+            actions.append(ModelActions.ENABLE)
+            if user_is_admin:
                 actions.append(ModelActions.DELETE)
-                actions.append(ModelActions.ENABLE)
 
         return actions
 
@@ -267,3 +290,37 @@ class IntegrationService:
             integration_is_valid = False
             message = f"Unexpected error: {str(e)}"
         return IntegrationValidationResponse(is_valid=integration_is_valid, message=message)
+
+    # Permissions
+    async def get_user_integration_policies(self, user_id: str) -> list[UserIntegrationResponse]:
+        policies = await self.crud.get_user_integration_policies(user_id)
+        return [UserIntegrationResponse.model_validate(policy) for policy in policies]
+
+    async def get_role_permissions(
+        self,
+        role_name: str,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[RoleIntegrationsResponse]:
+        policies = await self.crud.get_integration_policies_by_role(role_name, range=range, sort=sort)
+        return [RoleIntegrationsResponse.model_validate(policy) for policy in policies]
+
+    async def create_integration_policy(
+        self,
+        integration_policy: EntityPolicyCreate,
+        requester: UserDTO,
+    ) -> list[PermissionResponse]:
+        integration = await self.get_by_id(integration_policy.entity_id)
+        if not integration:
+            raise EntityNotFound(f"Integration {integration_policy.entity_id} not found")
+
+        policies: list[PermissionResponse] = []
+        try:
+            policy = await self.permission_service.create_entity_policy(
+                integration_policy, requester, reload_permission=False
+            )
+            policies.append(PermissionResponse.model_validate(policy))
+        except EntityExistsError:
+            pass
+        await self.permission_service.casbin_enforcer.send_reload_event()
+        return policies

--- a/server/src/application/integrations/service.py
+++ b/server/src/application/integrations/service.py
@@ -232,7 +232,7 @@ class IntegrationService:
         :return: List of actions
         """
         requester_permissions = await user_entity_permissions(requester, integration_id, "integration")
-        if "write" not in requester_permissions and "admin" not in requester_permissions:
+        if "admin" not in requester_permissions:
             return []
 
         actions: list[str] = []
@@ -240,16 +240,12 @@ class IntegrationService:
         if not integration:
             raise EntityNotFound("Integration not found")
 
-        user_is_admin = "admin" in requester_permissions
-
         if integration.status == ModelStatus.ENABLED:
-            if user_is_admin:
-                actions.append(ModelActions.EDIT)
+            actions.append(ModelActions.EDIT)
             actions.append(ModelActions.DISABLE)
         if integration.status == ModelStatus.DISABLED:
             actions.append(ModelActions.ENABLE)
-            if user_is_admin:
-                actions.append(ModelActions.DELETE)
+            actions.append(ModelActions.DELETE)
 
         return actions
 

--- a/server/src/application/integrations/service.py
+++ b/server/src/application/integrations/service.py
@@ -10,7 +10,7 @@ from core.base_models import PatchBodyModel
 from core.constants import ModelStatus
 from core.constants.model import ModelActions
 from core.database import to_dict
-from core.errors import CloudWrongCredentials, DependencyError, EntityExistsError, EntityNotFound, EntityWrongState
+from core.errors import CloudWrongCredentials, DependencyError, EntityNotFound, EntityWrongState
 from core.permissions.schema import EntityPolicyCreate, PermissionResponse
 from core.permissions.service import PermissionService
 from core.revisions.handler import RevisionHandler
@@ -68,11 +68,8 @@ class IntegrationService:
             return None
         return IntegrationResponse.model_validate(integration)
 
-    async def get_all(self, workspace_id: str | UUID | None = None, **kwargs) -> list[IntegrationResponse]:
-        if workspace_id is not None:
-            integrations = await self.crud.get_by_workspace_id(workspace_id)
-        else:
-            integrations = await self.crud.get_all(**kwargs)
+    async def get_all(self, **kwargs) -> list[IntegrationResponse]:
+        integrations = await self.crud.get_all(**kwargs)
         return [IntegrationResponse.model_validate(integration) for integration in integrations]
 
     async def get_all_dto(self, **kwargs) -> list[IntegrationDTO]:
@@ -315,12 +312,9 @@ class IntegrationService:
             raise EntityNotFound(f"Integration {integration_policy.entity_id} not found")
 
         policies: list[PermissionResponse] = []
-        try:
-            policy = await self.permission_service.create_entity_policy(
-                integration_policy, requester, reload_permission=False
-            )
-            policies.append(PermissionResponse.model_validate(policy))
-        except EntityExistsError:
-            pass
+        policy = await self.permission_service.create_entity_policy(
+            integration_policy, requester, reload_permission=False
+        )
+        policies.append(PermissionResponse.model_validate(policy))
         await self.permission_service.casbin_enforcer.send_reload_event()
         return policies

--- a/server/src/application/integrations/service.py
+++ b/server/src/application/integrations/service.py
@@ -243,7 +243,8 @@ class IntegrationService:
         user_is_admin = "admin" in requester_permissions
 
         if integration.status == ModelStatus.ENABLED:
-            actions.append(ModelActions.EDIT)
+            if user_is_admin:
+                actions.append(ModelActions.EDIT)
             actions.append(ModelActions.DISABLE)
         if integration.status == ModelStatus.DISABLED:
             actions.append(ModelActions.ENABLE)

--- a/server/src/application/resources/service.py
+++ b/server/src/application/resources/service.py
@@ -400,12 +400,16 @@ class ResourceService:
 
             # validate that integrations are allowed for the template and are enabled
             if resource.integration_ids is not None:
-                # require write access for any integration newly added by this patch
-                existing_integration_ids: set[str] = {
+                # require write access for any integration newly added by this patch;
+                # exempt integrations already on the resource and integrations inherited from parents
+                exempt_integration_ids: set[str] = {
                     str(i.id) for i in (existing_resource_pydantic.integration_ids or [])
                 }
+                for parent in existing_resource.parents or []:
+                    for parent_integration in parent.integration_ids or []:
+                        exempt_integration_ids.add(str(parent_integration.id))
                 for integration_id in resource.integration_ids:
-                    if str(integration_id) in existing_integration_ids:
+                    if str(integration_id) in exempt_integration_ids:
                         continue
                     integration_permissions = await user_entity_permissions(requester, integration_id, "integration")
                     if "write" not in integration_permissions and "admin" not in integration_permissions:

--- a/server/src/application/resources/service.py
+++ b/server/src/application/resources/service.py
@@ -29,7 +29,7 @@ from core.config import InfrakitchenConfig
 from core.constants import ModelStatus, ModelState
 from core.constants.model import ModelActions
 from core.database import to_dict
-from core.errors import DependencyError, EntityExistsError, EntityNotFound, EntityWrongState
+from core.errors import AccessDenied, DependencyError, EntityExistsError, EntityNotFound, EntityWrongState
 from core.logs.service import LogService
 from core.permissions.schema import EntityPolicyCreate, PermissionResponse
 from core.permissions.service import PermissionService
@@ -174,6 +174,19 @@ class ResourceService:
                 raise ValueError("Template requires integration. Integration ID is required")
 
             if resource.integration_ids:
+                # require write access to every integration the user explicitly chose;
+                # integrations inherited from a parent are exempt (read on the parent is enough)
+                inherited_integration_ids: set[str] = set()
+                for parent in parent_resources:
+                    for parent_integration in parent.integration_ids or []:
+                        inherited_integration_ids.add(str(parent_integration.id))
+                for integration_id in resource.integration_ids:
+                    if str(integration_id) in inherited_integration_ids:
+                        continue
+                    integration_permissions = await user_entity_permissions(requester, integration_id, "integration")
+                    if "write" not in integration_permissions and "admin" not in integration_permissions:
+                        raise AccessDenied(f"You don't have write access to integration {integration_id}")
+
                 # if template allows only specific integration types,
                 # check that number of integrations is equal to number of allowed types.
                 if template.configuration.allowed_provider_integration_types:
@@ -387,6 +400,17 @@ class ResourceService:
 
             # validate that integrations are allowed for the template and are enabled
             if resource.integration_ids is not None:
+                # require write access for any integration newly added by this patch
+                existing_integration_ids: set[str] = {
+                    str(i.id) for i in (existing_resource_pydantic.integration_ids or [])
+                }
+                for integration_id in resource.integration_ids:
+                    if str(integration_id) in existing_integration_ids:
+                        continue
+                    integration_permissions = await user_entity_permissions(requester, integration_id, "integration")
+                    if "write" not in integration_permissions and "admin" not in integration_permissions:
+                        raise AccessDenied(f"You don't have write access to integration {integration_id}")
+
                 if template := await self.template_service.get_by_id(existing_resource_pydantic.template.id):
                     if template.configuration.allowed_provider_integration_types:
                         if len(resource.integration_ids) != len(

--- a/server/src/core/sso/functions.py
+++ b/server/src/core/sso/functions.py
@@ -60,7 +60,7 @@ async def check_api_permission(request: Request):
         if "kubernetes" in request.url.path:
             entity = "provider_kubernetes"
 
-    if entity in ("resource", "resource_temp_state", "executor", "favorite", "provider_kubernetes"):
+    if entity in ("resource", "resource_temp_state", "executor", "favorite", "provider_kubernetes", "integration"):
         # Some entities have their own permission control system using the `user_has_access_to_entity` function
         if await user_has_access_to_api(user, "resource", "read"):
             return
@@ -69,6 +69,9 @@ async def check_api_permission(request: Request):
             return
 
         if await user_has_access_to_api(user, "favorite", "read"):
+            return
+
+        if await user_has_access_to_api(user, "integration", "read"):
             return
 
     if request.method not in request_action_mapping:

--- a/server/tests/application/integrations/test_integrations_service.py
+++ b/server/tests/application/integrations/test_integrations_service.py
@@ -513,6 +513,7 @@ class TestDelete:
         mocked_integration.status = ModelStatus.DISABLED
         mock_integration_crud.get_by_id.return_value = mocked_integration
         mock_integration_crud.get_dependencies.return_value = []
+        mock_integration_service.permission_service.delete_entity_permissions = AsyncMock()
 
         await mock_integration_service.delete(integration_id=mocked_integration.id, requester=mock_user_dto)
 
@@ -523,6 +524,9 @@ class TestDelete:
             mocked_integration.id, mock_user_dto.id, ModelActions.DELETE
         )
         mock_task_entity_crud.delete_by_entity_id.assert_awaited_once_with(mocked_integration.id)
+        mock_integration_service.permission_service.delete_entity_permissions.assert_awaited_once_with(
+            "integration", mocked_integration.id
+        )
 
     @pytest.mark.asyncio
     async def test_delete_error_enabled(

--- a/server/tests/application/integrations/test_integrations_service.py
+++ b/server/tests/application/integrations/test_integrations_service.py
@@ -152,6 +152,8 @@ class TestCreate:
         mocked_integration_response,
         mock_user_dto,
     ):
+        mock_integration_service.permission_service.create_entity_policy = AsyncMock()
+        mock_integration_service.permission_service.casbin_enforcer.send_reload_event = AsyncMock()
         cloud_integration_config = {
             "aws_account": "123456789012",
             "aws_access_key_id": "test_access_key",
@@ -177,7 +179,9 @@ class TestCreate:
         integration_create.integration_provider = "aws"
         integration_create.model_dump = Mock(return_value=integration_body)
 
-        new_integration = Integration(name="Test Integration", integration_type="cloud", integration_provider="aws")
+        new_integration = Integration(
+            id=uuid4(), name="Test Integration", integration_type="cloud", integration_provider="aws"
+        )
         mock_integration_crud.create.return_value = new_integration
         mock_integration_crud.get_by_id.return_value = mocked_integration
 
@@ -598,32 +602,32 @@ class TestGetIntegrationActions:
         [
             (
                 ModelStatus.ENABLED,
-                {"api:integration": "write"},
-                [],
+                ["read", "write"],
+                [ModelActions.EDIT, ModelActions.DISABLE],
             ),
             (
                 ModelStatus.ENABLED,
-                {"api:integration": "admin"},
+                ["read", "write", "admin"],
                 [ModelActions.EDIT, ModelActions.DISABLE],
             ),
             (
                 ModelStatus.DISABLED,
-                {"api:integration": "write"},
-                [],
+                ["read", "write"],
+                [ModelActions.ENABLE],
             ),
             (
                 ModelStatus.DISABLED,
-                {"api:integration": "admin"},
-                [ModelActions.DELETE, ModelActions.ENABLE],
+                ["read", "write", "admin"],
+                [ModelActions.ENABLE, ModelActions.DELETE],
             ),
             (
                 ModelStatus.ENABLED,
-                {"api:integration": "read"},
+                ["read"],
                 [],
             ),
             (
                 ModelStatus.ENABLED,
-                {},
+                [],
                 [],
             ),
         ],
@@ -643,7 +647,7 @@ class TestGetIntegrationActions:
         mock_user_permissions(
             user_permissions,
             monkeypatch,
-            "application.integrations.service.user_api_permission",
+            "application.integrations.service.user_entity_permissions",
         )
 
         mocked_integration.status = status

--- a/server/tests/application/integrations/test_integrations_service.py
+++ b/server/tests/application/integrations/test_integrations_service.py
@@ -607,7 +607,7 @@ class TestGetIntegrationActions:
             (
                 ModelStatus.ENABLED,
                 ["read", "write"],
-                [ModelActions.EDIT, ModelActions.DISABLE],
+                [ModelActions.DISABLE],
             ),
             (
                 ModelStatus.ENABLED,

--- a/server/tests/application/integrations/test_integrations_service.py
+++ b/server/tests/application/integrations/test_integrations_service.py
@@ -607,7 +607,7 @@ class TestGetIntegrationActions:
             (
                 ModelStatus.ENABLED,
                 ["read", "write"],
-                [ModelActions.DISABLE],
+                [],
             ),
             (
                 ModelStatus.ENABLED,
@@ -617,7 +617,7 @@ class TestGetIntegrationActions:
             (
                 ModelStatus.DISABLED,
                 ["read", "write"],
-                [ModelActions.ENABLE],
+                [],
             ),
             (
                 ModelStatus.DISABLED,

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -643,7 +643,7 @@ class TestCreate:
         except AccessDenied:
             pytest.fail("AccessDenied raised for an integration inherited from a parent")
         except Exception:
-            pass
+            pass  # unrelated to the permission check we're asserting on
 
         # the integration permission check must be skipped for inherited integrations
         for call in permissions_mock.await_args_list:
@@ -725,12 +725,13 @@ class TestPatch:
             ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
         )
 
+        # downstream may raise due to mocking limitations; only AccessDenied is under test here
         try:
             await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
         except AccessDenied:
             pytest.fail("AccessDenied raised for an integration inherited from a parent")
         except Exception:
-            pass
+            pass  # unrelated to the permission check we're asserting on
 
         for call in permissions_mock.await_args_list:
             assert call.args[1] != mocked_integration.id, (
@@ -771,7 +772,7 @@ class TestPatch:
         except AccessDenied:
             pytest.fail("AccessDenied raised for an integration already on the resource")
         except Exception:
-            pass
+            pass  # unrelated to the permission check we're asserting on
 
         # the integration permission check must be skipped for already-attached integrations
         for call in permissions_mock.await_args_list:

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -375,6 +375,8 @@ class TestCreate:
         mocked_resource,
         source_code_version_response,
         mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
     ):
         mocked_integration.status = ModelStatus.DISABLED
         resource_create = ResourceCreate(
@@ -388,6 +390,7 @@ class TestCreate:
         mock_template_crud.get_by_id.return_value = mocked_template
         mock_integration_crud.get_all.return_value = [mocked_integration]
         mock_source_code_version_crud.get_by_id.return_value = source_code_version_response
+        mock_user_permissions(["read", "write"], monkeypatch, "application.resources.service.user_entity_permissions")
 
         with pytest.raises(
             EntityWrongState,
@@ -438,6 +441,8 @@ class TestCreate:
         mocked_resource,
         source_code_version,
         mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
     ):
         source_code_version.template_id = mocked_template.id
         mocked_template.configuration["allowed_provider_integration_types"] = ["aws"]
@@ -457,6 +462,7 @@ class TestCreate:
         mock_resource_crud.create.return_value = mocked_resource
         mock_resource_crud.get_by_id.return_value = mocked_resource
         mock_resource_service.get_variable_schema = AsyncMock(return_value=[])
+        mock_user_permissions(["read", "write"], monkeypatch, "application.resources.service.user_entity_permissions")
 
         await mock_resource_service.create(resource_create, requester)
         mock_integration_crud.get_all.assert_awaited_once()
@@ -474,6 +480,8 @@ class TestCreate:
         mocked_resource,
         source_code_version,
         mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
     ):
         source_code_version.template_id = mocked_template.id
         mocked_template.configuration["allowed_provider_integration_types"] = ["gcp"]
@@ -492,6 +500,7 @@ class TestCreate:
         mock_source_code_version_crud.get_by_id.return_value = source_code_version
         mock_resource_crud.create.return_value = mocked_resource
         mock_resource_crud.get_by_id.return_value = mocked_resource
+        mock_user_permissions(["read", "write"], monkeypatch, "application.resources.service.user_entity_permissions")
 
         with pytest.raises(
             ValueError,
@@ -513,6 +522,8 @@ class TestCreate:
         mocked_resource,
         source_code_version,
         mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
     ):
         source_code_version.template_id = mocked_template.id
         mocked_template.configuration["one_resource_per_integration"] = ["aws"]
@@ -530,6 +541,7 @@ class TestCreate:
         mock_source_code_version_crud.get_by_id.return_value = source_code_version
         mock_resource_crud.create.return_value = mocked_resource
         mock_resource_crud.get_resource_by_template_and_integrations.return_value = [mocked_resource]
+        mock_user_permissions(["read", "write"], monkeypatch, "application.resources.service.user_entity_permissions")
 
         with pytest.raises(
             DependencyError,

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -595,20 +595,25 @@ class TestCreate:
         mock_integration_crud,
         mocked_integration,
         mocked_resource,
+        resource_response,
         source_code_version_response,
         mock_source_code_version_crud,
         mock_user_permissions,
         monkeypatch,
     ):
         # parent template + parent resource that already owns the integration
-        template_id = uuid4()
+        template_id = source_code_version_response.template.id
         parent_template_id = uuid4()
         template_response_with_parent = Mock(
             id=template_id,
             status=ModelStatus.ENABLED,
             abstract=False,
             parents=[Mock(id=parent_template_id)],
-            configuration=Mock(allowed_provider_integration_types=None, one_resource_per_integration=None),
+            configuration=Mock(
+                allowed_provider_integration_types=None,
+                one_resource_per_integration=None,
+                naming_convention=None,
+            ),
         )
         parent_resource = Mock(
             id=uuid4(),
@@ -632,20 +637,14 @@ class TestCreate:
         mock_source_code_version_crud.get_by_id.return_value = source_code_version_response
         mock_resource_crud.create.return_value = mocked_resource
         mock_resource_crud.get_by_id.return_value = mocked_resource
-        mock_resource_service.get_variable_schema = AsyncMock(return_value=[])
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=resource_response))
+        monkeypatch.setattr(ResourceService, "get_variable_schema", AsyncMock(return_value=[]))
         permissions_mock = mock_user_permissions(
             ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
         )
 
-        # should not raise AccessDenied — downstream may fail, that's fine
-        try:
-            await mock_resource_service.create(resource_create, requester)
-        except AccessDenied:
-            pytest.fail("AccessDenied raised for an integration inherited from a parent")
-        except Exception:
-            pass  # unrelated to the permission check we're asserting on
+        await mock_resource_service.create(resource_create, requester)
 
-        # the integration permission check must be skipped for inherited integrations
         for call in permissions_mock.await_args_list:
             assert call.args[1] != mocked_integration.id, (
                 "user_entity_permissions should not be called for inherited integrations"
@@ -720,18 +719,19 @@ class TestPatch:
         )
         monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
 
+        mock_resource_service.template_service.get_by_id = AsyncMock(
+            return_value=Mock(configuration=Mock(allowed_provider_integration_types=None))
+        )
+        mock_resource_service.integration_service.get_all_dto = AsyncMock(
+            return_value=[Mock(id=mocked_integration.id, status=ModelStatus.ENABLED, integration_provider="aws")]
+        )
+
         resource_patch = ResourcePatch(integration_ids=[mocked_integration.id])
         permissions_mock = mock_user_permissions(
             ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
         )
 
-        # downstream may raise due to mocking limitations; only AccessDenied is under test here
-        try:
-            await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
-        except AccessDenied:
-            pytest.fail("AccessDenied raised for an integration inherited from a parent")
-        except Exception:
-            pass  # unrelated to the permission check we're asserting on
+        await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
 
         for call in permissions_mock.await_args_list:
             assert call.args[1] != mocked_integration.id, (
@@ -761,20 +761,20 @@ class TestPatch:
         )
         monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
 
+        mock_resource_service.template_service.get_by_id = AsyncMock(
+            return_value=Mock(configuration=Mock(allowed_provider_integration_types=None))
+        )
+        mock_resource_service.integration_service.get_all_dto = AsyncMock(
+            return_value=[Mock(id=existing_integration_id, status=ModelStatus.ENABLED, integration_provider="aws")]
+        )
+
         resource_patch = ResourcePatch(integration_ids=[existing_integration_id])
         permissions_mock = mock_user_permissions(
             ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
         )
 
-        # may raise downstream (template lookup etc.), but must NOT raise AccessDenied
-        try:
-            await mock_resource_service.patch(mocked_resource.id, resource_patch, mocked_user)
-        except AccessDenied:
-            pytest.fail("AccessDenied raised for an integration already on the resource")
-        except Exception:
-            pass  # unrelated to the permission check we're asserting on
+        await mock_resource_service.patch(mocked_resource.id, resource_patch, mocked_user)
 
-        # the integration permission check must be skipped for already-attached integrations
         for call in permissions_mock.await_args_list:
             assert call.args[1] != existing_integration_id, (
                 "user_entity_permissions should not be called for already-attached integrations"

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -9,11 +9,12 @@ from application.resources.schema import (
     ResourceResponse,
     ResourceWithConfigs,
     ResourceCreate,
+    ResourcePatch,
 )
 from application.resources.service import ResourceService
 from core.config import InfrakitchenConfig
 from core.constants.model import ModelActions, ModelState, ModelStatus
-from core.errors import DependencyError, EntityNotFound, EntityWrongState
+from core.errors import AccessDenied, DependencyError, EntityNotFound, EntityWrongState
 from core.users.model import UserDTO
 
 RESOURCE_ID = "abc123"
@@ -550,6 +551,183 @@ class TestCreate:
             await mock_resource_service.create(resource_create, requester)
 
         assert len(exc.value.metadata) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_denies_integration_without_write_access(
+        self,
+        mock_resource_service,
+        mocked_user,
+        mocked_template,
+        mock_template_crud,
+        mock_integration_crud,
+        mocked_integration,
+        mocked_resource,
+        source_code_version_response,
+        mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        resource_create = ResourceCreate(
+            name=mocked_resource.name,
+            template_id=mocked_template.id,
+            source_code_version_id=source_code_version_response.id,
+            integration_ids=[mocked_integration.id],
+        )
+
+        requester = mocked_user
+        mock_template_crud.get_by_id.return_value = mocked_template
+        mock_integration_crud.get_all.return_value = [mocked_integration]
+        mock_source_code_version_crud.get_by_id.return_value = source_code_version_response
+        mock_user_permissions(["read"], monkeypatch, "application.resources.service.user_entity_permissions")
+
+        with pytest.raises(
+            AccessDenied,
+            match=f"You don't have write access to integration {mocked_integration.id}",
+        ):
+            await mock_resource_service.create(resource_create, requester)
+
+    @pytest.mark.asyncio
+    async def test_create_inherited_integration_is_exempt(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mock_integration_crud,
+        mocked_integration,
+        mocked_resource,
+        source_code_version_response,
+        mock_source_code_version_crud,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        # parent template + parent resource that already owns the integration
+        template_id = uuid4()
+        parent_template_id = uuid4()
+        template_response_with_parent = Mock(
+            id=template_id,
+            status=ModelStatus.ENABLED,
+            abstract=False,
+            parents=[Mock(id=parent_template_id)],
+            configuration=Mock(allowed_provider_integration_types=None, one_resource_per_integration=None),
+        )
+        parent_resource = Mock(
+            id=uuid4(),
+            template=Mock(id=parent_template_id),
+            state=ModelState.PROVISIONED,
+            integration_ids=[mocked_integration],
+        )
+
+        resource_create = ResourceCreate(
+            name=mocked_resource.name,
+            template_id=template_id,
+            source_code_version_id=source_code_version_response.id,
+            integration_ids=[mocked_integration.id],
+            parents=[parent_resource.id],
+        )
+
+        requester = mocked_user
+        mock_resource_service.template_service.get_by_id = AsyncMock(return_value=template_response_with_parent)
+        mock_resource_crud.get_all.return_value = [parent_resource]
+        mock_integration_crud.get_all.return_value = [mocked_integration]
+        mock_source_code_version_crud.get_by_id.return_value = source_code_version_response
+        mock_resource_crud.create.return_value = mocked_resource
+        mock_resource_crud.get_by_id.return_value = mocked_resource
+        mock_resource_service.get_variable_schema = AsyncMock(return_value=[])
+        permissions_mock = mock_user_permissions(
+            ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
+        )
+
+        # should not raise AccessDenied — downstream may fail, that's fine
+        try:
+            await mock_resource_service.create(resource_create, requester)
+        except AccessDenied:
+            pytest.fail("AccessDenied raised for an integration inherited from a parent")
+        except Exception:
+            pass
+
+        # the integration permission check must be skipped for inherited integrations
+        for call in permissions_mock.await_args_list:
+            assert call.args[1] != mocked_integration.id, (
+                "user_entity_permissions should not be called for inherited integrations"
+            )
+
+
+class TestPatch:
+    @pytest.mark.asyncio
+    async def test_patch_denies_newly_added_integration_without_write_access(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mocked_resource,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        new_integration_id = uuid4()
+        mocked_resource.state = ModelState.PROVISION
+        mocked_resource.status = ModelStatus.READY
+        mock_resource_crud.get_by_id.return_value = mocked_resource
+
+        # Existing resource pydantic carries the original integration_ids only.
+        # patch tries to add a brand new integration the user has no write access to.
+        existing_pydantic = Mock(
+            abstract=False,
+            integration_ids=[Mock(id=mocked_resource.integration_ids[0].id)],
+            template=Mock(id=mocked_resource.template_id),
+            parents=[],
+        )
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
+
+        resource_patch = ResourcePatch(integration_ids=[new_integration_id])
+        mock_user_permissions(["read"], monkeypatch, "application.resources.service.user_entity_permissions")
+
+        with pytest.raises(
+            AccessDenied,
+            match=f"You don't have write access to integration {new_integration_id}",
+        ):
+            await mock_resource_service.patch(mocked_resource.id, resource_patch, mocked_user)
+
+    @pytest.mark.asyncio
+    async def test_patch_existing_integration_is_exempt(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mocked_resource,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        existing_integration_id = mocked_resource.integration_ids[0].id
+        mocked_resource.state = ModelState.PROVISION
+        mocked_resource.status = ModelStatus.READY
+        mock_resource_crud.get_by_id.return_value = mocked_resource
+
+        existing_pydantic = Mock(
+            abstract=False,
+            integration_ids=[Mock(id=existing_integration_id)],
+            template=Mock(id=mocked_resource.template_id),
+            parents=[],
+        )
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
+
+        resource_patch = ResourcePatch(integration_ids=[existing_integration_id])
+        permissions_mock = mock_user_permissions(
+            ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
+        )
+
+        # may raise downstream (template lookup etc.), but must NOT raise AccessDenied
+        try:
+            await mock_resource_service.patch(mocked_resource.id, resource_patch, mocked_user)
+        except AccessDenied:
+            pytest.fail("AccessDenied raised for an integration already on the resource")
+        except Exception:
+            pass
+
+        # the integration permission check must be skipped for already-attached integrations
+        for call in permissions_mock.await_args_list:
+            assert call.args[1] != existing_integration_id, (
+                "user_entity_permissions should not be called for already-attached integrations"
+            )
 
 
 class TestDelete:

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -688,6 +688,56 @@ class TestPatch:
             await mock_resource_service.patch(mocked_resource.id, resource_patch, mocked_user)
 
     @pytest.mark.asyncio
+    async def test_patch_parent_inherited_integration_is_exempt(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mocked_integration,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        # existing resource has no integrations of its own, but its parent has one;
+        # patching the resource to add the parent's integration must not be denied.
+        parent_integration = Mock(id=mocked_integration.id)
+        parent = Mock(integration_ids=[parent_integration])
+        existing_resource = Mock(
+            id=uuid4(),
+            state=ModelState.PROVISION,
+            status=ModelStatus.READY,
+            template_id=uuid4(),
+            integration_ids=[],
+            parents=[parent],
+        )
+        mock_resource_crud.get_by_id.return_value = existing_resource
+        monkeypatch.setattr("application.resources.service.to_dict", Mock(return_value={}))
+
+        existing_pydantic = Mock(
+            abstract=False,
+            integration_ids=[],
+            template=Mock(id=existing_resource.template_id),
+            parents=[],
+        )
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
+
+        resource_patch = ResourcePatch(integration_ids=[mocked_integration.id])
+        permissions_mock = mock_user_permissions(
+            ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
+        )
+
+        try:
+            await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
+        except AccessDenied:
+            pytest.fail("AccessDenied raised for an integration inherited from a parent")
+        except Exception:
+            pass
+
+        for call in permissions_mock.await_args_list:
+            assert call.args[1] != mocked_integration.id, (
+                "user_entity_permissions should not be called for parent-inherited integrations"
+            )
+
+    @pytest.mark.asyncio
     async def test_patch_existing_integration_is_exempt(
         self,
         mock_resource_service,

--- a/server/tests/fixtures/test_integration_fixtures.py
+++ b/server/tests/fixtures/test_integration_fixtures.py
@@ -38,6 +38,7 @@ def mock_integration_service(
     mock_event_sender,
     mock_audit_log_handler,
     mock_task_entity_service,
+    mock_permission_service,
 ):
     return IntegrationService(
         crud=mock_integration_crud,
@@ -45,6 +46,7 @@ def mock_integration_service(
         event_sender=mock_event_sender,
         audit_log_handler=mock_audit_log_handler,
         task_service=mock_task_entity_service,
+        permission_service=mock_permission_service,
     )
 
 

--- a/ui/frontend-lib/src/common/components/inputs/ArrayReferenceInput.tsx
+++ b/ui/frontend-lib/src/common/components/inputs/ArrayReferenceInput.tsx
@@ -63,7 +63,7 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
       if (Array.isArray(value)) {
         onChange(value.map((entity) => String(entity.id)));
       } else if (value && typeof value === "object") {
-        onChange([value.id]);
+        onChange([String(value.id)]);
       } else {
         onChange([]);
       }

--- a/ui/frontend-lib/src/common/components/inputs/ArrayReferenceInput.tsx
+++ b/ui/frontend-lib/src/common/components/inputs/ArrayReferenceInput.tsx
@@ -6,6 +6,7 @@ import {
   TextField,
   Chip,
   FormHelperText,
+  Tooltip,
 } from "@mui/material";
 
 import { InfraKitchenApi } from "../../../api/InfraKitchenApi";
@@ -29,6 +30,8 @@ interface ArrayReferenceInputProps {
   value: any;
   error?: boolean;
   setBuffer: (selectedEntity: any) => void;
+  optionFilter?: (option: IkEntity) => boolean;
+  tooltip?: string;
   [key: string]: any; // Allow additional props
 }
 
@@ -46,6 +49,8 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
       filter = {},
       label,
       value,
+      optionFilter,
+      tooltip,
       ...otherProps
     } = props;
 
@@ -56,7 +61,7 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
       _details?: any,
     ) => {
       if (Array.isArray(value)) {
-        onChange(value.map((entity) => entity.id) || []);
+        onChange(value.map((entity) => String(entity.id)));
       } else if (value && typeof value === "object") {
         onChange([value.id]);
       } else {
@@ -67,6 +72,10 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
     const isOptionDisabled = (option: IkEntity) => option.status === "disabled";
 
     const resolvedBufferKey = bufferKey || entity_name;
+
+    const filteredOptions = optionFilter
+      ? (buffer[resolvedBufferKey] || []).filter(optionFilter)
+      : buffer[resolvedBufferKey] || [];
 
     useEffect(() => {
       ikApi
@@ -94,7 +103,7 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
       setBuffer,
     ]);
 
-    return (
+    const control = (
       <FormControl fullWidth margin="normal">
         <Autocomplete
           sx={{
@@ -118,7 +127,7 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
           defaultValue={otherProps.defaultValue || undefined}
           disabled={otherProps.disabled || false}
           getOptionDisabled={isOptionDisabled}
-          options={buffer[resolvedBufferKey] || []}
+          options={filteredOptions}
           getOptionLabel={(option) => getOptionLabel(option, showFields)}
           isOptionEqualToValue={(option, value) =>
             option.id === (value?.id || value)
@@ -177,6 +186,16 @@ const ArrayReferenceInput = forwardRef<any, ArrayReferenceInputProps>(
         </FormHelperText>
       </FormControl>
     );
+
+    if (tooltip) {
+      return (
+        <Tooltip title={tooltip} placement="top" arrow>
+          <span style={{ display: "block", width: "100%" }}>{control}</span>
+        </Tooltip>
+      );
+    }
+
+    return control;
   },
 );
 

--- a/ui/frontend-lib/src/filterRoutes.ts
+++ b/ui/frontend-lib/src/filterRoutes.ts
@@ -166,7 +166,7 @@ const allRoutes: LazyRouteDefinition[] = [
       "IntegrationEditPage",
     ),
     requiredPermission: "api:integration",
-    permissionAction: "write",
+    permissionAction: "read",
   },
   {
     path: "/integrations/:provider/:integration_id/:tab?",

--- a/ui/frontend-lib/src/integrations/components/IntegrationContent.tsx
+++ b/ui/frontend-lib/src/integrations/components/IntegrationContent.tsx
@@ -11,6 +11,7 @@ import { useEntityProvider } from "../../common/context/EntityContext";
 
 import { IntegrationConfiguration } from "./IntegrationConfiguration";
 import { IntegrationOverview } from "./IntegrationOverview";
+import { IntegrationPermissions } from "./IntegrationPermissions";
 import { IntegrationResources } from "./IntegrationResources";
 import { IntegrationSourceCodeDependencies } from "./IntegrationSourceCodeDependencies";
 import { IntegrationWorkspaceDependencies } from "./IntegrationWorkspaceDependencies";
@@ -56,15 +57,19 @@ export const IntegrationContent = () => {
       content: <Audit entityId={entity.id} showRevisionColumn />,
     },
     {
+      label: "Policies",
+      content: <IntegrationPermissions integration={entity} />,
+    },
+    {
       label: "Revisions",
       content: <Revision resourceId={entity.id} resourceRevision={0} />,
-      requiredPermission: "api:integration",
+      requiredPermission: `integration:${entity.id}`,
       permissionAction: "write" as const,
     },
     {
       label: "Settings",
       content: <DangerZoneCard />,
-      requiredPermission: "api:integration",
+      requiredPermission: `integration:${entity.id}`,
       permissionAction: "write" as const,
     },
   ];

--- a/ui/frontend-lib/src/integrations/components/IntegrationContent.tsx
+++ b/ui/frontend-lib/src/integrations/components/IntegrationContent.tsx
@@ -70,7 +70,7 @@ export const IntegrationContent = () => {
       label: "Settings",
       content: <DangerZoneCard />,
       requiredPermission: `integration:${entity.id}`,
-      permissionAction: "write" as const,
+      permissionAction: "admin" as const,
     },
   ];
 

--- a/ui/frontend-lib/src/integrations/components/IntegrationPermissions.tsx
+++ b/ui/frontend-lib/src/integrations/components/IntegrationPermissions.tsx
@@ -1,0 +1,17 @@
+import { EntityPoliciesTab } from "../../permissions/components/policies/EntityPoliciesTab";
+import { IntegrationResponse } from "../types";
+
+export interface IntegrationPermissionsProps {
+  integration: IntegrationResponse;
+}
+
+export const IntegrationPermissions = ({
+  integration,
+}: IntegrationPermissionsProps) => {
+  return (
+    <EntityPoliciesTab
+      entity_id={integration.id}
+      entity_name={integration._entity_name}
+    />
+  );
+};

--- a/ui/frontend-lib/src/integrations/pages/Integration.tsx
+++ b/ui/frontend-lib/src/integrations/pages/Integration.tsx
@@ -49,7 +49,7 @@ export const IntegrationPage = () => {
         title={"Integration Overview"}
         actions={
           <PermissionWrapper
-            requiredPermission="api:integration"
+            requiredPermission={`integration:${integration_id || ""}`}
             permissionAction="write"
           >
             <Button

--- a/ui/frontend-lib/src/permissions/components/policies/EntityRolePoliciesCreateCard.tsx
+++ b/ui/frontend-lib/src/permissions/components/policies/EntityRolePoliciesCreateCard.tsx
@@ -200,7 +200,7 @@ export const EntityRolePolicyCreateCard = (
             </FormControl>
           )}
         />
-        {entity_id && !role_name && (
+        {entity_id && !role_name && entity_name !== "integration" && (
           <Controller
             name="inherits_children"
             control={control}

--- a/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
@@ -274,22 +274,27 @@ const ResourceCreatePageInner = () => {
   }, [watchedParentIds, watchedTemplate, buffer]);
 
   const inherited = useMemo(() => {
-    const integrationIds =
-      (resolvedLastParent as ResourceResponse | null)?.integration_ids?.map(
-        (i: { id: string }) => i.id,
-      ) || [];
+    const parent = resolvedLastParent as ResourceResponse | null;
+    const integrationIds = parent?.integration_ids?.map((i) => i.id) || [];
     return {
       integration: integrationIds.length > 0,
-      storage: Boolean((resolvedLastParent as any)?.storage?.id),
-      workspace: Boolean((resolvedLastParent as any)?.workspace?.id),
+      storage: Boolean(parent?.storage?.id),
+      workspace: Boolean(parent?.workspace?.id),
       integrationIds,
-      storageId: (resolvedLastParent as any)?.storage?.id || null,
-      workspaceId: (resolvedLastParent as any)?.workspace?.id || null,
+      storageId: parent?.storage?.id || null,
+      workspaceId: parent?.workspace?.id || null,
     };
   }, [resolvedLastParent]);
 
+  const lastAppliedParentIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!resolvedLastParent) return;
+    if (!resolvedLastParent) {
+      lastAppliedParentIdRef.current = null;
+      return;
+    }
+    const parentId = String((resolvedLastParent as IkEntity).id);
+    if (lastAppliedParentIdRef.current === parentId) return;
+    lastAppliedParentIdRef.current = parentId;
     if (inherited.integration) {
       setValue("integration_ids", inherited.integrationIds);
     }

--- a/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
@@ -44,6 +44,7 @@ import TagInput from "../../common/components/inputs/TagInput";
 import { MarkdownViewer } from "../../common/components/MarkdownViewer";
 import { PropertyCard } from "../../common/components/PropertyCard";
 import { useConfig } from "../../common/context/ConfigContext";
+import { usePermissionProvider } from "../../common/context/PermissionContext";
 import { notify, notifyError } from "../../common/hooks/useNotification";
 import PageContainer from "../../common/PageContainer";
 import { TemplateResponse } from "../../templates/types";
@@ -63,12 +64,12 @@ import { buildValidationRuleMaps } from "../utils/validationRules";
 
 const ResourceCreatePageInner = () => {
   const { ikApi, linkPrefix } = useConfig();
+  const { permissions } = usePermissionProvider();
   const {
     control,
     formState: { errors },
     watch,
     setValue,
-    getValues,
     handleSubmit,
   } = useFormContext<ResourceCreate>();
 
@@ -80,7 +81,6 @@ const ResourceCreatePageInner = () => {
   const [variablesOpen, setVariablesOpen] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [parentsSelected, setParentsSelected] = useState(false);
   const [buffer, setBuffer] = useState<Record<string, IkEntity | IkEntity[]>>(
     {},
   );
@@ -217,6 +217,15 @@ const ResourceCreatePageInner = () => {
 
   const watchedName = watch("name");
 
+  const integrationWriteFilter = useMemo(
+    () => (option: IkEntity) => {
+      if (permissions["*"] === "admin") return true;
+      const p = permissions[`integration:${option.id}`];
+      return p === "write" || p === "admin";
+    },
+    [permissions],
+  );
+
   useEffect(() => {
     if (watchedTemplate?.configuration?.naming_convention) {
       setNamingConvention(watchedTemplate.configuration.naming_convention);
@@ -249,53 +258,43 @@ const ResourceCreatePageInner = () => {
     }
   }, [watchedName, watchedTemplate, setValue]);
 
-  useEffect(() => {
-    if (watchedParentIds.length > 0) {
-      // override integration_ids, storage_id and workspace_id based on the last parent selection
-      const parentCandidates = watchedTemplate?.parents
-        ? watchedTemplate.parents.flatMap(
-            (parent: IkEntity) =>
-              (buffer[String(parent.id)] as IkEntity[]) || [],
-          )
-        : [];
-
-      const primaryParentId = watchedParentIds.at(-1);
-      const parentObjects = parentCandidates.find(
+  const resolvedLastParent = useMemo(() => {
+    if (watchedParentIds.length === 0) return null;
+    const parentCandidates = watchedTemplate?.parents
+      ? watchedTemplate.parents.flatMap(
+          (parent: IkEntity) => (buffer[String(parent.id)] as IkEntity[]) || [],
+        )
+      : [];
+    const primaryParentId = watchedParentIds.at(-1);
+    return (
+      parentCandidates.find(
         (e: ResourceResponse) => String(e.id) === String(primaryParentId),
-      );
+      ) || null
+    );
+  }, [watchedParentIds, watchedTemplate, buffer]);
 
-      if (!parentObjects) {
-        return;
-      }
+  const inherited = useMemo(() => {
+    const integrationIds =
+      (resolvedLastParent as ResourceResponse | null)?.integration_ids?.map(
+        (i: { id: string }) => i.id,
+      ) || [];
+    return {
+      integration: integrationIds.length > 0,
+      storage: Boolean((resolvedLastParent as any)?.storage?.id),
+      integrationIds,
+      storageId: (resolvedLastParent as any)?.storage?.id || null,
+    };
+  }, [resolvedLastParent]);
 
-      const parentIntegrations =
-        parentObjects.integration_ids.map(
-          (integration: { id: string }) => integration.id,
-        ) || [];
-
-      const parentStorage = parentObjects?.storage?.id || null;
-      const parentWorkspace = parentObjects?.workspace?.id || null;
-
-      if (
-        parentIntegrations.length > 0 &&
-        watchedTemplate.parents.length === watchedParentIds.length &&
-        !parentsSelected
-      ) {
-        setParentsSelected(true);
-        setValue("integration_ids", parentIntegrations);
-      }
-
-      setValue("storage_id", parentStorage);
-      setValue("workspace_id", parentWorkspace);
+  useEffect(() => {
+    if (!resolvedLastParent) return;
+    if (inherited.integration) {
+      setValue("integration_ids", inherited.integrationIds);
     }
-  }, [
-    watchedParentIds,
-    setValue,
-    getValues,
-    buffer,
-    watchedTemplate,
-    parentsSelected,
-  ]);
+    if (inherited.storage) {
+      setValue("storage_id", inherited.storageId);
+    }
+  }, [resolvedLastParent, inherited, setValue]);
 
   useEffect(() => {
     if (watchedSourceCodeVersionId) {
@@ -730,10 +729,21 @@ const ResourceCreatePageInner = () => {
                         buffer={buffer}
                         setBuffer={setBuffer}
                         error={!!errors.integration_ids}
+                        optionFilter={(option: IkEntity) => {
+                          if (
+                            inherited.integration &&
+                            inherited.integrationIds.includes(option.id)
+                          ) {
+                            return true;
+                          }
+                          return integrationWriteFilter(option);
+                        }}
                         helpertext={
                           errors.integration_ids
                             ? (errors.integration_ids as any).message
-                            : ""
+                            : inherited.integration
+                              ? "Pre-filled from parent. You can remove inherited integrations or add others you have write access to."
+                              : "Only integrations you have write access to are shown"
                         }
                         value={field.value}
                         label={`Cloud Integrations. ${

--- a/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
@@ -281,8 +281,10 @@ const ResourceCreatePageInner = () => {
     return {
       integration: integrationIds.length > 0,
       storage: Boolean((resolvedLastParent as any)?.storage?.id),
+      workspace: Boolean((resolvedLastParent as any)?.workspace?.id),
       integrationIds,
       storageId: (resolvedLastParent as any)?.storage?.id || null,
+      workspaceId: (resolvedLastParent as any)?.workspace?.id || null,
     };
   }, [resolvedLastParent]);
 
@@ -293,6 +295,9 @@ const ResourceCreatePageInner = () => {
     }
     if (inherited.storage) {
       setValue("storage_id", inherited.storageId);
+    }
+    if (inherited.workspace) {
+      setValue("workspace_id", inherited.workspaceId);
     }
   }, [resolvedLastParent, inherited, setValue]);
 

--- a/ui/frontend-lib/src/resources/pages/ResourceEdit.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceEdit.tsx
@@ -39,6 +39,7 @@ import ArrayReferenceInput from "../../common/components/inputs/ArrayReferenceIn
 import ReferenceInput from "../../common/components/inputs/ReferenceInput";
 import TagInput from "../../common/components/inputs/TagInput";
 import { PropertyCard } from "../../common/components/PropertyCard";
+import { usePermissionProvider } from "../../common/context/PermissionContext";
 import { notify, notifyError } from "../../common/hooks/useNotification";
 import PageContainer from "../../common/PageContainer";
 import {
@@ -65,7 +66,21 @@ export const ResourceEditPageInner = (props: {
   resourceTempState?: ResourceTempStateResponse;
 }) => {
   const { linkPrefix, ikApi } = useConfig();
+  const { permissions } = usePermissionProvider();
   const { entity, resourceTempState } = props;
+  const existingIntegrationIds = useMemo(
+    () => new Set(entity.integration_ids.map((i) => String(i.id))),
+    [entity.integration_ids],
+  );
+  const integrationOptionFilter = useMemo(
+    () => (option: IkEntity) => {
+      if (existingIntegrationIds.has(String(option.id))) return true;
+      if (permissions["*"] === "admin") return true;
+      const p = permissions[`integration:${option.id}`];
+      return p === "write" || p === "admin";
+    },
+    [existingIntegrationIds, permissions],
+  );
   const navigate = useNavigate();
   const handleBack = () => navigate(`${linkPrefix}resources/${entity.id}`);
   const [variablesOpen, setVariablesOpen] = useState(true);
@@ -465,10 +480,11 @@ export const ResourceEditPageInner = (props: {
                         buffer={buffer}
                         setBuffer={setBuffer}
                         error={!!errors.integration_ids}
+                        optionFilter={integrationOptionFilter}
                         helpertext={
                           errors.integration_ids
                             ? errors.integration_ids.message
-                            : "Select Credentials for the resource"
+                            : "Existing integrations are kept; new options are limited to those you have write access to."
                         }
                         value={field.value}
                         label="Cloud Integrations"


### PR DESCRIPTION
This PR 

- Introduces the standard permission control for integrations

<img width="1348" height="1002" alt="image" src="https://github.com/user-attachments/assets/03c55b9c-a4aa-4ead-868f-811b48e7b977" />

- Updates Resource Creation and Edit to limit the list of available integrations to the ones the user has `write` or `admin` access to, also limits on the backend, if a user tries to create a resource with an integration he has no access to then he receives a `403` error.
<img width="1106" height="760" alt="image" src="https://github.com/user-attachments/assets/caeb9c65-ab95-4d60-8089-903394e83f97" />
