### PR TITLE
Workspace permission control

### DIFF
--- a/server/src/application/integrations/dependencies.py
+++ b/server/src/application/integrations/dependencies.py
@@ -3,7 +3,6 @@ from fastapi import Depends
 from core.audit_logs.handler import AuditLogHandler
 from core.dependencies import get_db_session
 from core.permissions.dependencies import get_permission_service
-from core.permissions.service import PermissionService
 from core.revisions.handler import RevisionHandler
 from core.tasks.dependencies import get_task_service
 from core.utils.event_sender import EventSender
@@ -16,7 +15,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def get_integration_service(
     session: AsyncSession = Depends(get_db_session),
-    permission_service: PermissionService = Depends(get_permission_service),
 ) -> IntegrationService:
     revision_handler = RevisionHandler(session=session, entity_name="integration")
     event_sender = EventSender(entity_name="integration")
@@ -27,5 +25,5 @@ def get_integration_service(
         event_sender=event_sender,
         audit_log_handler=audit_log_handler,
         task_service=get_task_service(session=session),
-        permission_service=permission_service,
+        permission_service=get_permission_service(session=session),
     )

--- a/server/src/application/resources/service.py
+++ b/server/src/application/resources/service.py
@@ -250,6 +250,12 @@ class ResourceService:
                 if missing:
                     raise ValueError(f"Missing required dependency config variable(s): {', '.join(missing)}")
 
+            # Validate if user has write permission to linked workspace
+            if resource.workspace_id is not None:
+                workspace_permissions = await user_entity_permissions(requester, resource.workspace_id, "workspace")
+                if "write" not in workspace_permissions and "admin" not in workspace_permissions:
+                    raise AccessDenied(f"You don't have write access to workspace {resource.workspace_id}")
+
             # validate configuration variables
             if source_code_version_id := resource.source_code_version_id:
                 source_code_version = await self.service_source_code_version.get_by_id(source_code_version_id)
@@ -462,6 +468,13 @@ class ResourceService:
 
                 else:
                     raise EntityNotFound("Template not found")
+
+            if resource.workspace_id is not None and str(resource.workspace_id) != str(
+                existing_resource.workspace_id or ""
+            ):
+                workspace_permissions = await user_entity_permissions(requester, resource.workspace_id, "workspace")
+                if "write" not in workspace_permissions and "admin" not in workspace_permissions:
+                    raise AccessDenied(f"You don't have write access to workspace {resource.workspace_id}")
 
         body = resource.model_dump(exclude_unset=True)
 

--- a/server/src/application/workspaces/api.py
+++ b/server/src/application/workspaces/api.py
@@ -3,11 +3,21 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi import status as http_status
 
 from core.constants.model import ModelActions
+from core.permissions.dependencies import get_permission_service
+from core.permissions.schema import EntityPolicyCreate, PermissionResponse
+from core.permissions.service import PermissionService
+from core.users.functions import user_entity_permissions
 from core.users.model import UserDTO
 from core.utils.fastapi_tools import QueryParamsType, parse_query_params
 from infrakitchen_mcp.dispatch_framework import get_one_group, list_entities_group
 from infrakitchen_mcp.registry import mcp_group
-from .schema import WorkspaceCreate, WorkspaceResponse, WorkspaceUpdate
+from .schema import (
+    RoleWorkspacesResponse,
+    UserWorkspaceResponse,
+    WorkspaceCreate,
+    WorkspaceResponse,
+    WorkspaceUpdate,
+)
 from .dependencies import get_workspace_service
 from .service import WorkspaceService
 
@@ -72,7 +82,7 @@ async def post(request: Request, body: WorkspaceCreate, service: WorkspaceServic
     return entity
 
 
-@router.put(
+@router.patch(
     "/workspaces/{workspace_id}",
     response_model=WorkspaceResponse,
     status_code=http_status.HTTP_200_OK,
@@ -108,3 +118,61 @@ async def delete(request: Request, workspace_id: str, service: WorkspaceService 
 async def get_actions(request: Request, workspace_id: str, service: WorkspaceService = Depends(get_workspace_service)):
     requester = request.state.user
     return await service.get_actions(workspace_id=workspace_id, requester=requester)
+
+
+# Permissions
+@router.get(
+    "/workspaces/permissions/user/{user_id}/policies",
+    response_model=list[UserWorkspaceResponse],
+    response_description="Get user workspace policies",
+    status_code=http_status.HTTP_200_OK,
+)
+async def get_user_workspaces(user_id: str, service: WorkspaceService = Depends(get_workspace_service)):
+    return await service.get_user_workspace_policies(user_id)
+
+
+@router.get(
+    "/workspaces/permissions/role/{role_name}/policies",
+    response_model=list[RoleWorkspacesResponse],
+    response_description="Get role policies",
+    status_code=http_status.HTTP_200_OK,
+)
+async def get_workspace_role_permissions(
+    response: Response,
+    role_name: str,
+    service: WorkspaceService = Depends(get_workspace_service),
+    permission_service: PermissionService = Depends(get_permission_service),
+    query_parts: QueryParamsType = Depends(parse_query_params),
+):
+    _, range_, sort, _ = query_parts
+
+    total = await permission_service.count(filter={"v0": role_name, "ptype": "p", "v1__like": "workspace:"})
+
+    if total == 0:
+        result = []
+    else:
+        result = await service.get_role_permissions(role_name, range=range_, sort=sort)
+    headers = {"Content-Range": f"policies 0-{len(result)}/{total}"}
+    response.headers.update(headers)
+
+    return result
+
+
+@router.post(
+    "/workspaces/permissions",
+    response_model=list[PermissionResponse],
+    response_description="Create workspace policy",
+    status_code=http_status.HTTP_201_CREATED,
+)
+async def create_role_workspace_permissions(
+    request: Request,
+    workspace_policy: EntityPolicyCreate,
+    service: WorkspaceService = Depends(get_workspace_service),
+):
+    requester: UserDTO = request.state.user
+
+    requester_permissions = await user_entity_permissions(requester, workspace_policy.entity_id, "workspace")
+    if "admin" not in requester_permissions:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    return await service.create_workspace_policy(workspace_policy, requester=requester)

--- a/server/src/application/workspaces/crud.py
+++ b/server/src/application/workspaces/crud.py
@@ -1,11 +1,12 @@
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, literal, select
+from sqlalchemy import String, cast, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from application.integrations.model import Integration
 from application.resources.model import Resource
+from core.permissions.model import Permission
 from core.users.model import User
 
 from core.database import evaluate_sqlalchemy_filters, evaluate_sqlalchemy_pagination, evaluate_sqlalchemy_sorting
@@ -76,3 +77,66 @@ class WorkspaceCRUD:
 
     async def refresh(self, workspace: Workspace) -> None:
         await self.session.refresh(workspace)
+
+    async def get_workspace_policies_by_role(
+        self,
+        role_name: str,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[Any]:
+        workspace_id_expr = func.split_part(Permission.v1, ":", 2)
+        statement = (
+            select(
+                Workspace.id.label("workspace_id"),
+                Workspace.name.label("workspace_name"),
+                Permission.v0.label("role"),
+                Permission.v2.label("action"),
+                Permission.id.label("id"),
+                Permission.created_at.label("created_at"),
+                Permission.updated_at.label("updated_at"),
+            )
+            .join(
+                Permission,
+                cast(Workspace.id, String) == workspace_id_expr,
+            )
+            .where(
+                Permission.ptype == "p",
+                Permission.v1.like("workspace:%"),
+                Permission.v0 == role_name,
+            )
+        )
+        statement = evaluate_sqlalchemy_sorting(Permission, statement, sort)
+        statement = evaluate_sqlalchemy_pagination(statement, range)
+        result = await self.session.execute(statement)
+        return list(result.fetchall())
+
+    async def get_user_workspace_policies(
+        self,
+        user_id: str,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[Any]:
+        workspace_id_expr = func.split_part(Permission.v1, ":", 2)
+        statement = (
+            select(
+                Workspace.id.label("workspace_id"),
+                Workspace.name.label("workspace_name"),
+                Permission.v2.label("action"),
+                Permission.id.label("id"),
+                Permission.created_at.label("created_at"),
+                Permission.updated_at.label("updated_at"),
+            )
+            .join(
+                Permission,
+                cast(Workspace.id, String) == workspace_id_expr,
+            )
+            .where(
+                Permission.ptype == "p",
+                Permission.v1.like("workspace:%"),
+                Permission.v0 == f"user:{user_id}",
+            )
+        )
+        statement = evaluate_sqlalchemy_sorting(Permission, statement, sort)
+        statement = evaluate_sqlalchemy_pagination(statement, range)
+        result = await self.session.execute(statement)
+        return list(result.fetchall())

--- a/server/src/application/workspaces/dependencies.py
+++ b/server/src/application/workspaces/dependencies.py
@@ -4,7 +4,6 @@ from core.audit_logs.handler import AuditLogHandler
 from core.dependencies import get_db_session
 from core.logs.dependencies import get_log_service
 from core.permissions.dependencies import get_permission_service
-from core.permissions.service import PermissionService
 from core.tasks.dependencies import get_task_service
 from core.utils.event_sender import EventSender
 
@@ -16,7 +15,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def get_workspace_service(
     session: AsyncSession = Depends(get_db_session),
-    permission_service: PermissionService = Depends(get_permission_service),
 ) -> WorkspaceService:
     event_sender = EventSender(entity_name="workspace")
     audit_log_handler = AuditLogHandler(session=session, entity_name="workspace")
@@ -26,5 +24,5 @@ def get_workspace_service(
         audit_log_handler=audit_log_handler,
         log_service=get_log_service(session=session),
         task_service=get_task_service(session=session),
-        permission_service=permission_service,
+        permission_service=get_permission_service(session=session),
     )

--- a/server/src/application/workspaces/dependencies.py
+++ b/server/src/application/workspaces/dependencies.py
@@ -3,6 +3,8 @@ from fastapi import Depends
 from core.audit_logs.handler import AuditLogHandler
 from core.dependencies import get_db_session
 from core.logs.dependencies import get_log_service
+from core.permissions.dependencies import get_permission_service
+from core.permissions.service import PermissionService
 from core.tasks.dependencies import get_task_service
 from core.utils.event_sender import EventSender
 
@@ -14,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 def get_workspace_service(
     session: AsyncSession = Depends(get_db_session),
+    permission_service: PermissionService = Depends(get_permission_service),
 ) -> WorkspaceService:
     event_sender = EventSender(entity_name="workspace")
     audit_log_handler = AuditLogHandler(session=session, entity_name="workspace")
@@ -23,4 +26,5 @@ def get_workspace_service(
         audit_log_handler=audit_log_handler,
         log_service=get_log_service(session=session),
         task_service=get_task_service(session=session),
+        permission_service=permission_service,
     )

--- a/server/src/application/workspaces/schema.py
+++ b/server/src/application/workspaces/schema.py
@@ -209,3 +209,26 @@ class WorkspaceShort(BaseModel):
     @computed_field
     def _entity_name(self) -> str:
         return "workspace"
+
+
+class RoleWorkspacesResponse(BaseModel):
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    workspace_name: str
+    role: str
+    action: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserWorkspaceResponse(BaseModel):
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    workspace_name: str
+    action: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/server/src/application/workspaces/service.py
+++ b/server/src/application/workspaces/service.py
@@ -1,12 +1,15 @@
 import logging
+from uuid import UUID
 from typing import Any
 
 from core.audit_logs.handler import AuditLogHandler
 from core.constants.model import ModelActions
 from core.errors import DependencyError, EntityNotFound
 from core.logs.service import LogService
+from core.permissions.schema import EntityPolicyCreate, PermissionResponse
+from core.permissions.service import PermissionService
 from core.tasks.service import TaskEntityService
-from core.users.functions import user_api_permission
+from core.users.functions import user_entity_permissions
 from core.utils.event_sender import EventSender
 from core.utils.model_tools import model_db_dump
 from .crud import WorkspaceCRUD
@@ -14,6 +17,8 @@ from .schema import (
     AzureDevOpsWorkspaceMeta,
     BitbucketWorkspaceMeta,
     GithubWorkspaceMeta,
+    RoleWorkspacesResponse,
+    UserWorkspaceResponse,
     WorkspaceCreate,
     WorkspaceMeta,
     WorkspaceResponse,
@@ -38,14 +43,16 @@ class WorkspaceService:
         audit_log_handler: AuditLogHandler,
         log_service: LogService,
         task_service: TaskEntityService,
+        permission_service: PermissionService,
     ):
         self.crud: WorkspaceCRUD = crud
         self.event_sender: EventSender = event_sender
         self.audit_log_handler: AuditLogHandler = audit_log_handler
         self.log_service: LogService = log_service
         self.task_service: TaskEntityService = task_service
+        self.permission_service: PermissionService = permission_service
 
-    async def get_by_id(self, workspace_id: str) -> WorkspaceResponse | None:
+    async def get_by_id(self, workspace_id: str | UUID) -> WorkspaceResponse | None:
         workspace = await self.crud.get_by_id(workspace_id)
         if workspace is None:
             return None
@@ -93,6 +100,17 @@ class WorkspaceService:
         await self.audit_log_handler.create_log(new_workspace.id, requester.id, ModelActions.CREATE)
         response = WorkspaceResponse.model_validate(result)
         await self.event_sender.send_event(response, ModelActions.CREATE)
+        await self.permission_service.create_entity_policy(
+            EntityPolicyCreate(
+                user_id=requester.id,
+                entity_id=new_workspace.id,
+                entity_name="workspace",
+                action="admin",
+            ),
+            requester=requester,
+            reload_permission=False,
+        )
+        await self.permission_service.casbin_enforcer.send_reload_event()
         return response
 
     async def update(self, workspace_id: str, workspace: WorkspaceUpdate, requester: UserDTO) -> WorkspaceResponse:
@@ -112,6 +130,7 @@ class WorkspaceService:
         await self.crud.update(existing_workspace, body)
 
         await self.audit_log_handler.create_log(existing_workspace.id, requester.id, ModelActions.UPDATE)
+        await self.crud.refresh(existing_workspace)
         response = WorkspaceResponse.model_validate(existing_workspace)
         await self.event_sender.send_event(response, ModelActions.UPDATE)
         return response
@@ -141,6 +160,7 @@ class WorkspaceService:
         )
         await self.log_service.delete_by_entity_id(workspace_id)
         await self.task_service.delete_by_entity_id(workspace_id)
+        await self.permission_service.delete_entity_permissions("workspace", workspace_id)
         await self.crud.delete(existing_workspace)
 
     async def get_actions(self, workspace_id: str, requester: UserDTO) -> list[str]:
@@ -150,20 +170,43 @@ class WorkspaceService:
         :param workspace_id: ID of the workspace
         :return: List of actions
         """
-        apis = await user_api_permission(requester, "workspace")
-        if not apis:
-            return []
-        requester_permissions = [apis["api:workspace"]]
-
-        if "write" not in requester_permissions and "admin" not in requester_permissions:
+        requester_permissions = await user_entity_permissions(requester, workspace_id, "workspace")
+        if "admin" not in requester_permissions:
             return []
 
-        actions: list[str] = []
         workspace = await self.crud.get_by_id(workspace_id)
         if not workspace:
-            raise EntityNotFound("Source Code not found")
+            raise EntityNotFound("Workspace not found")
 
-        if "admin" in requester_permissions:
-            actions.append(ModelActions.DELETE)
+        return [ModelActions.EDIT, ModelActions.DELETE]
 
-        return actions
+    # Permissions
+    async def get_user_workspace_policies(self, user_id: str) -> list[UserWorkspaceResponse]:
+        policies = await self.crud.get_user_workspace_policies(user_id)
+        return [UserWorkspaceResponse.model_validate(policy) for policy in policies]
+
+    async def get_role_permissions(
+        self,
+        role_name: str,
+        range: tuple[int, int] | None = None,
+        sort: tuple[str, str] | None = None,
+    ) -> list[RoleWorkspacesResponse]:
+        policies = await self.crud.get_workspace_policies_by_role(role_name, range=range, sort=sort)
+        return [RoleWorkspacesResponse.model_validate(policy) for policy in policies]
+
+    async def create_workspace_policy(
+        self,
+        workspace_policy: EntityPolicyCreate,
+        requester: UserDTO,
+    ) -> list[PermissionResponse]:
+        workspace = await self.get_by_id(workspace_policy.entity_id)
+        if not workspace:
+            raise EntityNotFound(f"Workspace {workspace_policy.entity_id} not found")
+
+        policies: list[PermissionResponse] = []
+        policy = await self.permission_service.create_entity_policy(
+            workspace_policy, requester, reload_permission=False
+        )
+        policies.append(PermissionResponse.model_validate(policy))
+        await self.permission_service.casbin_enforcer.send_reload_event()
+        return policies

--- a/server/src/core/sso/functions.py
+++ b/server/src/core/sso/functions.py
@@ -60,7 +60,15 @@ async def check_api_permission(request: Request):
         if "kubernetes" in request.url.path:
             entity = "provider_kubernetes"
 
-    if entity in ("resource", "resource_temp_state", "executor", "favorite", "provider_kubernetes", "integration"):
+    if entity in (
+        "resource",
+        "resource_temp_state",
+        "executor",
+        "favorite",
+        "provider_kubernetes",
+        "integration",
+        "workspace",
+    ):
         # Some entities have their own permission control system using the `user_has_access_to_entity` function
         if await user_has_access_to_api(user, "resource", "read"):
             return
@@ -72,6 +80,9 @@ async def check_api_permission(request: Request):
             return
 
         if await user_has_access_to_api(user, "integration", "read"):
+            return
+
+        if await user_has_access_to_api(user, "workspace", "read"):
             return
 
     if request.method not in request_action_mapping:

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -600,6 +600,9 @@ class TestCreate:
         resource_response,
         source_code_version,
         mock_source_code_version_crud,
+        mocked_storage,
+        mock_storage_crud,
+        storage_response,
         monkeypatch,
     ):
         source_code_version.template_id = mocked_template.id
@@ -609,6 +612,8 @@ class TestCreate:
             name=mocked_resource.name,
             template_id=mocked_template.id,
             source_code_version_id=source_code_version.id,
+            storage_id=storage_response.id,
+            storage_path="path/to/storage",
             dependency_config=[
                 DependencyConfig(name="env", value="prod"),
             ],
@@ -617,6 +622,7 @@ class TestCreate:
         requester = mocked_user
         mock_template_crud.get_by_id.return_value = mocked_template
         mock_source_code_version_crud.get_by_id.return_value = source_code_version
+        mock_storage_crud.get_by_id.return_value = mocked_storage
 
         new_resource = Resource(
             name=mocked_resource.name, template_id=mocked_template.id, created_by=requester.id, revision_number=1

--- a/server/tests/application/resources/service/test_resource_service.py
+++ b/server/tests/application/resources/service/test_resource_service.py
@@ -728,6 +728,48 @@ class TestCreate:
                 "user_entity_permissions should not be called for inherited integrations"
             )
 
+    @pytest.mark.asyncio
+    async def test_create_denies_workspace_without_write_access(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mock_template_crud,
+        mock_storage_crud,
+        mock_source_code_version_crud,
+        monkeypatch,
+        template_response,
+        mocked_resource,
+        resource_response,
+        source_code_version_response,
+        storage_response,
+        mocked_user_response,
+        mock_user_permissions,
+    ):
+        workspace_id = uuid4()
+        resource_create = ResourceCreate(
+            name=mocked_resource.name,
+            template_id=template_response.id,
+            source_code_version_id=source_code_version_response.id,
+            storage_id=storage_response.id,
+            storage_path="path/to/storage",
+            workspace_id=workspace_id,
+        )
+
+        mock_template_crud.get_by_id.return_value = template_response
+        mock_storage_crud.get_by_id.return_value = storage_response
+        mock_source_code_version_crud.get_by_id.return_value = source_code_version_response
+        mock_resource_crud.create.return_value = mocked_resource
+        mock_resource_crud.get_by_id.return_value = mocked_resource
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=resource_response))
+        monkeypatch.setattr(ResourceService, "get_variable_schema", AsyncMock(return_value=[]))
+        mock_user_permissions(["read"], monkeypatch, "application.resources.service.user_entity_permissions")
+
+        with pytest.raises(
+            AccessDenied,
+            match=f"You don't have write access to workspace {workspace_id}",
+        ):
+            await mock_resource_service.create(resource_create, mocked_user_response)
+
 
 class TestPatch:
     @pytest.mark.asyncio
@@ -856,6 +898,98 @@ class TestPatch:
         for call in permissions_mock.await_args_list:
             assert call.args[1] != existing_integration_id, (
                 "user_entity_permissions should not be called for already-attached integrations"
+            )
+
+    @pytest.mark.asyncio
+    async def test_patch_denies_changing_workspace_without_write_access(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        existing_workspace_id = uuid4()
+        new_workspace_id = uuid4()
+        existing_resource = Mock(
+            id=uuid4(),
+            state=ModelState.PROVISION,
+            status=ModelStatus.READY,
+            template_id=uuid4(),
+            integration_ids=[],
+            parents=[],
+            workspace_id=existing_workspace_id,
+        )
+        mock_resource_crud.get_by_id.return_value = existing_resource
+        monkeypatch.setattr("application.resources.service.to_dict", Mock(return_value={}))
+
+        existing_pydantic = Mock(
+            abstract=False,
+            integration_ids=[],
+            template=Mock(id=existing_resource.template_id),
+            parents=[],
+        )
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
+
+        mock_resource_service.template_service.get_by_id = AsyncMock(
+            return_value=Mock(configuration=Mock(allowed_provider_integration_types=None))
+        )
+        mock_resource_service.integration_service.get_all_dto = AsyncMock(return_value=[])
+
+        resource_patch = ResourcePatch(workspace_id=new_workspace_id)
+        mock_user_permissions(["read"], monkeypatch, "application.resources.service.user_entity_permissions")
+
+        with pytest.raises(
+            AccessDenied,
+            match=f"You don't have write access to workspace {new_workspace_id}",
+        ):
+            await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
+
+    @pytest.mark.asyncio
+    async def test_patch_same_workspace_is_exempt(
+        self,
+        mock_resource_service,
+        mock_resource_crud,
+        mocked_user,
+        mock_user_permissions,
+        monkeypatch,
+    ):
+        existing_workspace_id = uuid4()
+        existing_resource = Mock(
+            id=uuid4(),
+            state=ModelState.PROVISION,
+            status=ModelStatus.READY,
+            template_id=uuid4(),
+            integration_ids=[],
+            parents=[],
+            workspace_id=existing_workspace_id,
+        )
+        mock_resource_crud.get_by_id.return_value = existing_resource
+        monkeypatch.setattr("application.resources.service.to_dict", Mock(return_value={}))
+
+        existing_pydantic = Mock(
+            abstract=False,
+            integration_ids=[],
+            template=Mock(id=existing_resource.template_id),
+            parents=[],
+        )
+        monkeypatch.setattr(ResourceResponse, "model_validate", Mock(return_value=existing_pydantic))
+
+        mock_resource_service.template_service.get_by_id = AsyncMock(
+            return_value=Mock(configuration=Mock(allowed_provider_integration_types=None))
+        )
+        mock_resource_service.integration_service.get_all_dto = AsyncMock(return_value=[])
+
+        resource_patch = ResourcePatch(workspace_id=existing_workspace_id)
+        permissions_mock = mock_user_permissions(
+            ["read"], monkeypatch, "application.resources.service.user_entity_permissions"
+        )
+
+        await mock_resource_service.patch(existing_resource.id, resource_patch, mocked_user)
+
+        for call in permissions_mock.await_args_list:
+            assert call.args[1] != existing_workspace_id, (
+                "user_entity_permissions should not be called when workspace is unchanged"
             )
 
 

--- a/server/tests/application/resources/service/test_resource_service_patch.py
+++ b/server/tests/application/resources/service/test_resource_service_patch.py
@@ -142,6 +142,8 @@ class TestPatch:
         mocked_resource,
         mocked_resource_temp_state_handler,
         mock_revision_handler,
+        mock_user_permissions,
+        monkeypatch,
     ):
         resource_patch = ResourcePatch(
             name="name",
@@ -169,6 +171,9 @@ class TestPatch:
         mock_resource_service.resource_temp_state_handler = mocked_resource_temp_state_handler
         mock_resource_service.revision_handler = mock_revision_handler
         mock_template_crud.get_by_id.return_value = mocked_template
+        mock_user_permissions(
+            ["read", "write", "admin"], monkeypatch, "application.resources.service.user_entity_permissions"
+        )
 
         result = await mock_resource_service.patch(
             resource_id=str(resource_id), resource=resource_patch, requester=mocked_user_response

--- a/server/tests/application/workspaces/test_workspace_api.py
+++ b/server/tests/application/workspaces/test_workspace_api.py
@@ -229,7 +229,7 @@ class TestUpdate:
         service = MockWorkspaceService(actions=[])
         override_service(service)
 
-        response = client_with_user.put(f"/workspaces/{WORKSPACE_ID}", json=workspace_update)
+        response = client_with_user.patch(f"/workspaces/{WORKSPACE_ID}", json=workspace_update)
 
         assert response.status_code == HTTPStatus.FORBIDDEN
         assert response.json() == {"detail": "Access denied for action edit"}
@@ -244,7 +244,7 @@ class TestUpdate:
         service = MockWorkspaceService(updated_workspace=workspace_response, actions=[ModelActions.EDIT])
         override_service(service)
 
-        response = client_with_user.put(f"/workspaces/{WORKSPACE_ID}", json=workspace_update)
+        response = client_with_user.patch(f"/workspaces/{WORKSPACE_ID}", json=workspace_update)
         json_response = response.json()
 
         assert response.status_code == HTTPStatus.OK

--- a/server/tests/application/workspaces/test_workspace_service.py
+++ b/server/tests/application/workspaces/test_workspace_service.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from pydantic import PydanticUserError
 from uuid import uuid4
@@ -193,20 +193,24 @@ class TestCreate:
             "organization": "test_owner",
         }
 
+        requester_id = uuid4()
         expected_workspace_body = model_db_dump(workspace_create)
-        expected_workspace_body["created_by"] = "user1"
+        expected_workspace_body["created_by"] = requester_id
         expected_workspace_body["name"] = workspace_create.configuration.name
         expected_workspace_body["configuration"] = expected_workspace_configuration
         requester = Mock(spec=UserDTO)
-        requester.id = "user1"
+        requester.id = requester_id
 
         new_workspace = Workspace(
+            id=uuid4(),
             name="Test Workspace",
             workspace_provider="github",
             configuration=expected_workspace_configuration,
         )
         mock_workspace_crud.create.return_value = new_workspace
         mock_workspace_crud.get_by_id.return_value = workspace
+        mock_workspace_service.permission_service.create_entity_policy = AsyncMock()
+        mock_workspace_service.permission_service.casbin_enforcer.send_reload_event = AsyncMock()
 
         monkeypatch.setattr(WorkspaceResponse, "model_validate", Mock(return_value=workspace_response))
 
@@ -281,20 +285,24 @@ class TestCreate:
             "organization": "org",
         }
 
+        requester_id = uuid4()
         expected_workspace_body = model_db_dump(workspace_create)
-        expected_workspace_body["created_by"] = "user1"
+        expected_workspace_body["created_by"] = requester_id
         expected_workspace_body["name"] = workspace_create.configuration.name
         expected_workspace_body["configuration"] = expected_workspace_configuration
         requester = Mock(spec=UserDTO)
-        requester.id = "user1"
+        requester.id = requester_id
 
         new_workspace = Workspace(
+            id=uuid4(),
             name="Test Workspace",
             workspace_provider="github",
             configuration=expected_workspace_configuration,
         )
         mock_workspace_crud.create.return_value = new_workspace
         mock_workspace_crud.get_by_id.return_value = workspace
+        mock_workspace_service.permission_service.create_entity_policy = AsyncMock()
+        mock_workspace_service.permission_service.casbin_enforcer.send_reload_event = AsyncMock()
 
         monkeypatch.setattr(WorkspaceResponse, "model_validate", Mock(return_value=workspace_response))
 
@@ -435,6 +443,7 @@ class TestDelete:
         )
         mock_workspace_crud.get_by_id.return_value = existing_workspace
         mock_workspace_crud.get_dependencies.return_value = []
+        mock_workspace_service.permission_service.delete_entity_permissions = AsyncMock()
 
         await mock_workspace_service.delete(workspace_id=workspace_id)
 
@@ -445,6 +454,9 @@ class TestDelete:
         )
         mock_log_crud.delete_by_entity_id.assert_awaited_once_with(workspace_id)
         mock_task_entity_crud.delete_by_entity_id.assert_awaited_once_with(workspace_id)
+        mock_workspace_service.permission_service.delete_entity_permissions.assert_awaited_once_with(
+            "workspace", workspace_id
+        )
 
     @pytest.mark.asyncio
     async def test_delete_workspace_does_not_exist(
@@ -459,3 +471,37 @@ class TestDelete:
         mock_log_crud.delete_by_entity_id.assert_not_awaited()
         mock_audit_log_handler.create_log.assert_not_awaited()
         mock_task_entity_crud.delete_by_entity_id.assert_not_awaited()
+
+
+class TestGetWorkspaceActions:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "user_permissions,expected_actions",
+        [
+            (["read"], []),
+            (["read", "write"], []),
+            (["read", "write", "admin"], [ModelActions.EDIT, ModelActions.DELETE]),
+            ([], []),
+        ],
+    )
+    async def test_get_workspace_actions(
+        self,
+        user_permissions,
+        expected_actions,
+        mock_workspace_service,
+        mock_workspace_crud,
+        workspace,
+        monkeypatch,
+        mock_user_dto,
+        mock_user_permissions,
+    ):
+        mock_user_permissions(
+            user_permissions,
+            monkeypatch,
+            "application.workspaces.service.user_entity_permissions",
+        )
+        mock_workspace_crud.get_by_id.return_value = workspace
+
+        result = await mock_workspace_service.get_actions(workspace_id=workspace.id, requester=mock_user_dto)
+
+        assert result == expected_actions

--- a/server/tests/fixtures/test_workspace_fixtures.py
+++ b/server/tests/fixtures/test_workspace_fixtures.py
@@ -31,6 +31,7 @@ def mock_workspace_service(
     mock_audit_log_handler,
     mock_log_service,
     mock_task_entity_service,
+    mock_permission_service,
 ):
     return WorkspaceService(
         crud=mock_workspace_crud,
@@ -38,6 +39,7 @@ def mock_workspace_service(
         audit_log_handler=mock_audit_log_handler,
         log_service=mock_log_service,
         task_service=mock_task_entity_service,
+        permission_service=mock_permission_service,
     )
 
 

--- a/ui/frontend-lib/src/common/components/inputs/ReferenceInput.tsx
+++ b/ui/frontend-lib/src/common/components/inputs/ReferenceInput.tsx
@@ -26,6 +26,7 @@ interface ReferenceInputProps {
   buffer: Record<string, IkEntity>;
   bufferKey?: string;
   setBuffer: (selectedEntity: any) => void;
+  optionFilter?: (option: IkEntity) => boolean;
   [key: string]: any; // Allow additional props
 }
 
@@ -40,14 +41,19 @@ const ReferenceInput = forwardRef<any, ReferenceInputProps>((props, _ref) => {
     filter = {},
     showFields = ["name"],
     value,
+    optionFilter,
     ...otherProps
   } = props;
 
   const resolvedBufferKey = bufferKey || entity_name;
-  const options: IkEntity[] = buffer[resolvedBufferKey] || [];
+  const allOptions: IkEntity[] = buffer[resolvedBufferKey] || [];
+  const options: IkEntity[] = optionFilter
+    ? allOptions.filter(optionFilter)
+    : allOptions;
   const [warning, setWarning] = useState<string | null>(null);
 
-  const selectedOption = options.find((option) => option.id === value) || null;
+  const selectedOption =
+    allOptions.find((option) => option.id === value) || null;
 
   const handleAutocompleteChange = (
     event: React.SyntheticEvent,

--- a/ui/frontend-lib/src/filterRoutes.ts
+++ b/ui/frontend-lib/src/filterRoutes.ts
@@ -528,7 +528,7 @@ const allRoutes: LazyRouteDefinition[] = [
       "WorkspaceEditPage",
     ),
     requiredPermission: "api:workspace",
-    permissionAction: "write",
+    permissionAction: "read",
   },
   {
     path: "/workspaces/:workspace_id/:tab?",

--- a/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceCreate.tsx
@@ -226,6 +226,15 @@ const ResourceCreatePageInner = () => {
     [permissions],
   );
 
+  const workspaceWriteFilter = useMemo(
+    () => (option: IkEntity) => {
+      if (permissions["*"] === "admin") return true;
+      const p = permissions[`workspace:${option.id}`];
+      return p === "write" || p === "admin";
+    },
+    [permissions],
+  );
+
   useEffect(() => {
     if (watchedTemplate?.configuration?.naming_convention) {
       setNamingConvention(watchedTemplate.configuration.naming_convention);
@@ -900,10 +909,11 @@ const ResourceCreatePageInner = () => {
                         showFields={["name", "workspace_provider"]}
                         setBuffer={setBuffer}
                         error={!!errors.workspace_id}
+                        optionFilter={workspaceWriteFilter}
                         helpertext={
                           errors.workspace_id
                             ? errors.workspace_id.message
-                            : "Select Workspace"
+                            : "Only workspaces you have write access to are shown"
                         }
                         value={field.value}
                         label="Select Workspace"

--- a/ui/frontend-lib/src/resources/pages/ResourceEdit.tsx
+++ b/ui/frontend-lib/src/resources/pages/ResourceEdit.tsx
@@ -81,6 +81,19 @@ export const ResourceEditPageInner = (props: {
     },
     [existingIntegrationIds, permissions],
   );
+  const existingWorkspaceId = entity.workspace?.id
+    ? String(entity.workspace.id)
+    : null;
+  const workspaceOptionFilter = useMemo(
+    () => (option: IkEntity) => {
+      if (existingWorkspaceId && String(option.id) === existingWorkspaceId)
+        return true;
+      if (permissions["*"] === "admin") return true;
+      const p = permissions[`workspace:${option.id}`];
+      return p === "write" || p === "admin";
+    },
+    [existingWorkspaceId, permissions],
+  );
   const navigate = useNavigate();
   const handleBack = () => navigate(`${linkPrefix}resources/${entity.id}`);
   const [variablesOpen, setVariablesOpen] = useState(true);
@@ -673,10 +686,11 @@ export const ResourceEditPageInner = (props: {
                           buffer={buffer}
                           setBuffer={setBuffer}
                           error={!!errors.workspace_id}
+                          optionFilter={workspaceOptionFilter}
                           helpertext={
                             errors.workspace_id
                               ? errors.workspace_id.message
-                              : "Select Workspace"
+                              : "Only workspaces you have write access to are shown"
                           }
                           value={field.value}
                           label="Workspace"

--- a/ui/frontend-lib/src/workspaces/components/WorkspaceContent.tsx
+++ b/ui/frontend-lib/src/workspaces/components/WorkspaceContent.tsx
@@ -10,6 +10,7 @@ import { useEntityProvider } from "../../common/context/EntityContext";
 
 import { WorkspaceConfiguration } from "./WorkspaceConfiguration";
 import { WorkspaceOverview } from "./WorkspaceOverview";
+import { WorkspacePermissions } from "./WorkspacePermissions";
 import { WorkspacePullRequests } from "./WorkspacePullRequests";
 import { WorkspaceRepository } from "./WorkspaceRepository";
 import { WorkspaceResources } from "./WorkspaceResources";
@@ -48,10 +49,14 @@ export const WorkspaceContent = () => {
       content: <Audit entityId={entity.id} />,
     },
     {
+      label: "Policies",
+      content: <WorkspacePermissions workspace={entity} />,
+    },
+    {
       label: "Settings",
       content: <DangerZoneCard />,
       requiredPermission: `workspace:${entity.id}`,
-      permissionAction: "write" as const,
+      permissionAction: "admin" as const,
     },
   ];
 

--- a/ui/frontend-lib/src/workspaces/components/WorkspacePermissions.tsx
+++ b/ui/frontend-lib/src/workspaces/components/WorkspacePermissions.tsx
@@ -1,0 +1,17 @@
+import { EntityPoliciesTab } from "../../permissions/components/policies/EntityPoliciesTab";
+import { WorkspaceResponse } from "../types";
+
+export interface WorkspacePermissionsProps {
+  workspace: WorkspaceResponse;
+}
+
+export const WorkspacePermissions = ({
+  workspace,
+}: WorkspacePermissionsProps) => {
+  return (
+    <EntityPoliciesTab
+      entity_id={workspace.id}
+      entity_name={workspace._entity_name}
+    />
+  );
+};


### PR DESCRIPTION
Workspaces now have the standard permission control

<img width="1186" height="815" alt="image" src="https://github.com/user-attachments/assets/a182d295-5f98-4080-89bd-d73cd5af6e1d" />

Every actions is locked behind admin permission, the above screenshot shows the write permission has nothing, the below shows that admin permission opens up edit page and settings tab.

<img width="1323" height="976" alt="image" src="https://github.com/user-attachments/assets/55477ca2-4ffa-45f6-9cdb-8730aca37876" />

Resource create and edit form's workspace field are now filtered based on write permission per-workspace.

This PR also fixes a minor bug where the edit form used `PATCH` while the backend was expecting `PUT`
