### PR TITLE
Improve CodeSnapshot for SCVs

### DIFF
--- a/server/src/application/source_code_versions/task.py
+++ b/server/src/application/source_code_versions/task.py
@@ -197,7 +197,14 @@ class SourceCodeVersionTask:
                 else self.git_client.destination_dir
             )
             self.logger.info(f"Starting file parsing in directory: {destination_dir}")
-            otf = OtfProvider(destination_dir)
+            otf = OtfProvider(
+                destination_dir,
+                repo_root=self.git_client.destination_dir,
+                repo_url=self.source_code_instance.source_code_url,
+                source_code_ref=branch,
+                git_client=self.git_client,
+                follow_modules=True,
+            )
 
             tf_data = await otf.parse_tf_directory_to_json()
 

--- a/server/src/application/source_code_versions/task.py
+++ b/server/src/application/source_code_versions/task.py
@@ -197,7 +197,19 @@ class SourceCodeVersionTask:
                 else self.git_client.destination_dir
             )
             self.logger.info(f"Starting file parsing in directory: {destination_dir}")
-            otf = OtfProvider(
+
+            main_otf = OtfProvider(destination_dir)
+            tf_data = await main_otf.parse_tf_directory_to_json()
+
+            variables = main_otf.remap_variable_types(main_otf.list_to_dict(tf_data.get("variable", [])))
+            vars = [VariableModel.get_from_named_dict(variables, v) for v in variables]
+            self.source_code_version_instance.variables = [v.model_dump() for v in vars]
+
+            outputs = main_otf.list_to_dict(tf_data.get("output", []))
+            outpts = [OutputVariableModel.get_from_named_dict(outputs, o) for o in outputs]
+            self.source_code_version_instance.outputs = [o.model_dump() for o in outpts]
+
+            snapshot_otf = OtfProvider(
                 destination_dir,
                 repo_root=self.git_client.destination_dir,
                 repo_url=self.source_code_instance.source_code_url,
@@ -205,21 +217,15 @@ class SourceCodeVersionTask:
                 git_client=self.git_client,
                 follow_modules=True,
             )
+            await snapshot_otf.read_files_to_string()
 
-            tf_data = await otf.parse_tf_directory_to_json()
-
-            variables = otf.remap_variable_types(otf.list_to_dict(tf_data.get("variable", [])))
-            vars = [VariableModel.get_from_named_dict(variables, v) for v in variables]
-
-            self.source_code_version_instance.variables = [v.model_dump() for v in vars]
-            outputs = otf.list_to_dict(tf_data.get("output", []))
-            outpts = [OutputVariableModel.get_from_named_dict(outputs, o) for o in outputs]
-            self.source_code_version_instance.outputs = [o.model_dump() for o in outpts]
             if not self.source_code_version_instance.code_snapshot:
-                self.source_code_version_instance.code_snapshot = otf.tf_string_data
+                self.source_code_version_instance.code_snapshot = snapshot_otf.tf_string_data
             else:
-                self._log_code_snapshot_drift(self.source_code_version_instance.code_snapshot, otf.tf_string_data)
-                self.source_code_version_instance.code_snapshot = otf.tf_string_data
+                self._log_code_snapshot_drift(
+                    self.source_code_version_instance.code_snapshot, snapshot_otf.tf_string_data
+                )
+                self.source_code_version_instance.code_snapshot = snapshot_otf.tf_string_data
             self.logger.info(f"Variables found: {len(self.source_code_version_instance.variables)}")
             self.logger.info(f"Outputs found: {len(self.source_code_version_instance.outputs)}")
 

--- a/server/src/application/tools/tf_parser.py
+++ b/server/src/application/tools/tf_parser.py
@@ -291,7 +291,8 @@ class OtfProvider:
                 if git_match is None:
                     continue
                 subpath, ref = git_match
-                results.append(ModuleRef(source, ref or parent_ref, subpath))
+                # No `?ref=` → Terraform pulls the default branch tip; mirror that.
+                results.append(ModuleRef(source, ref or "HEAD", subpath))
         return results
 
     @staticmethod

--- a/server/src/application/tools/tf_parser.py
+++ b/server/src/application/tools/tf_parser.py
@@ -1,10 +1,20 @@
+import logging
 import os
+import posixpath
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 import aiofiles
 import hcl2
 from aiofiles.os import listdir, path
+
+logger = logging.getLogger(__name__)
+
+
+class ModuleRef(NamedTuple):
+    source: str
+    ref: str | None
+    subpath: str
 
 
 class HclVariableParser:
@@ -100,11 +110,59 @@ class HclVariableParser:
 class OtfProvider:
     """Main class for handling OpenTofu/Terraform operations."""
 
-    def __init__(self, workspace) -> None:
+    # Terraform treats a module source as a local path only when it begins with
+    # "./" or "../"; anything else is a registry/git/external reference.
+    LOCAL_MODULE_PREFIXES = ("./", "../")
+
+    # Used as the per-file divider in `tf_string_data`. The `{}` is filled with
+    # the file's display name.
+    _FILE_DIVIDER = f"\n# {'-' * 30} FILE: {{}} {'-' * 30} \n"
+
+    # Matches a git repo URL in any of the common shapes:
+    #   https://github.com/foo/bar.git, ssh://git@github.com/foo/bar.git,
+    #   git@github.com:foo/bar.git, github.com/foo/bar
+    _REPO_URL_RE = re.compile(
+        r"^(?:[a-z][a-z0-9+.-]*://)?(?:[^@/]+@)?([^/:?#]+)[:/]([^?#]+?)(?:\.git)?/?$",
+        re.IGNORECASE,
+    )
+
+    def __init__(
+        self,
+        workspace,
+        repo_root: str | None = None,
+        repo_url: str | None = None,
+        source_code_ref: str | None = None,
+        git_client: Any = None,
+        follow_modules: bool = False,
+    ) -> None:
         self.workspace: str = workspace
+        self.repo_root: str = os.path.abspath(repo_root or workspace)
+        self.repo_url: str | None = repo_url
+        self.repo_id: str | None = self._normalize_repo_id(repo_url) if repo_url else None
+        self.source_code_ref: str | None = source_code_ref
+        self.git_client: Any = git_client
+        # Opt-in: when True, `read_files_to_string` follows `module` references
+        # SourceCodeVersions want to follow the modules in the terraform files
+        # while Resources and Executors only care about the current directory.
+        self.follow_modules: bool = follow_modules
         self.depth: int = 1  # Depth of the directory tree when adding files
         self.directory: str | None = None
         self.tf_string_data: str = ""
+
+    @classmethod
+    def _normalize_repo_id(cls, url: str) -> str | None:
+        """Reduce a git URL to a "host/owner/repo" identifier, stripping
+        scheme, user, .git suffix, trailing slash. Returns None if it doesn't
+        look like a git repo URL."""
+        if not url:
+            return None
+        s = url.strip().removeprefix("git::")
+        s = s.split("?", 1)[0]
+        match = cls._REPO_URL_RE.match(s)
+        if not match:
+            return None
+        host, path = match.group(1), match.group(2)
+        return f"{host.lower()}/{path}"
 
     def parse_tf_to_json(self, tf_data: str) -> dict[str, Any]:
         dict_data: dict[str, Any] = hcl2.loads(
@@ -178,19 +236,129 @@ class OtfProvider:
             data = await file.read()
         return data
 
-    async def read_files_to_string(self) -> None:
-        """Read multiple files and concatenate their contents into a single string."""
+    def _parse_same_repo_git_source(self, source: str) -> tuple[str, str | None] | None:
+        """If `source` is a `git::...//subpath[?ref=...]` reference whose repo
+        matches this OtfProvider's `repo_url`, return `(subpath, ref)`.
+        """
+        if not self.repo_id or not source.startswith("git::"):
+            return None
 
-        """Parse all Terraform files in a given folder to JSON."""
-        files: list[str] = []
-        await self.traverse_directories(files, self.workspace)
-        divider_string = f"\n# {'-' * 30} FILE: {{}} {'-' * 30} \n"
-        for f in files:
+        # Split off the ref query first so it doesn't confuse URL parsing.
+        body, _, query = source.removeprefix("git::").partition("?")
+        ref: str | None = None
+        if query:
+            for param in query.split("&"):
+                if param.startswith("ref="):
+                    ref = param[len("ref=") :]
+                    break
+
+        body_no_scheme = body.split("://", 1)[1] if "://" in body else body
+        if "//" not in body_no_scheme:
+            return None
+
+        repo_part, subpath = body_no_scheme.split("//", 1)
+        if self._normalize_repo_id(repo_part) != self.repo_id:
+            return None
+
+        return subpath.strip("/"), ref
+
+    def _extract_module_refs(self, tf_data: str, parent_subpath: str, parent_ref: str | None) -> list[ModuleRef]:
+        try:
+            dict_data: dict[str, Any] = hcl2.loads(
+                tf_data,
+                serialization_options=hcl2.SerializationOptions(strip_string_quotes=True, explicit_blocks=False),
+            )
+        except Exception:
+            return []
+
+        results: list[ModuleRef] = []
+        for block in dict_data.get("module", []):
+            if not isinstance(block, dict):
+                continue
+            for module_config in block.values():
+                source = module_config.get("source") if isinstance(module_config, dict) else None
+                if not isinstance(source, str):
+                    continue
+
+                if source.startswith(self.LOCAL_MODULE_PREFIXES):
+                    new_subpath = posixpath.normpath(posixpath.join(parent_subpath, source))
+                    if new_subpath.startswith("..") or new_subpath == ".":
+                        continue
+                    results.append(ModuleRef(source, parent_ref, new_subpath))
+                    continue
+
+                git_match = self._parse_same_repo_git_source(source)
+                if git_match is None:
+                    continue
+                subpath, ref = git_match
+                results.append(ModuleRef(source, ref or parent_ref, subpath))
+        return results
+
+    @staticmethod
+    async def _list_tf_files(directory: str) -> list[str]:
+        if not await path.isdir(directory):
+            return []
+        return [os.path.join(directory, name) for name in await listdir(directory) if name.endswith(".tf")]
+
+    async def read_files_to_string(self) -> None:
+        initial_files: list[str] = []
+        await self.traverse_directories(initial_files, self.workspace)
+
+        visited: set[tuple[str | None, str]] = set()
+        queue: list[ModuleRef] = []
+
+        for f in initial_files:
             if not f.endswith(".tf"):
                 continue
-            self.tf_string_data += divider_string.format(os.path.relpath(f, self.workspace))
-            self.tf_string_data += await self.read_file_to_string(f)
-            self.tf_string_data += "\n"
+            rel = os.path.relpath(f, self.repo_root).replace(os.sep, "/")
+            parent_subpath = posixpath.dirname(rel) or "."
+            visited.add((self.source_code_ref, parent_subpath))
+            content = await self.read_file_to_string(f)
+            display = f"{rel}@{self.source_code_ref}" if self.source_code_ref else rel
+            self.tf_string_data += self._FILE_DIVIDER.format(display)
+            self.tf_string_data += content + "\n"
+            if self.follow_modules:
+                queue.extend(self._extract_module_refs(content, parent_subpath, self.source_code_ref))
+
+        while queue:
+            mod = queue.pop(0)
+            key = (mod.ref, mod.subpath)
+            if key in visited:
+                continue
+            visited.add(key)
+
+            if mod.ref == self.source_code_ref:
+                abs_dir = os.path.join(self.repo_root, mod.subpath)
+                tf_files = await self._list_tf_files(abs_dir)
+                logger.info(f"[tf_parser] including module '{mod.source}' -> {mod.subpath} ({len(tf_files)} .tf files)")
+                for tf_file in tf_files:
+                    content = await self.read_file_to_string(tf_file)
+                    rel = os.path.relpath(tf_file, self.repo_root).replace(os.sep, "/")
+                    display = f"{rel}@{mod.ref}" if mod.ref else rel
+                    self.tf_string_data += self._FILE_DIVIDER.format(display)
+                    self.tf_string_data += content + "\n"
+                    queue.extend(self._extract_module_refs(content, mod.subpath, mod.ref))
+                continue
+
+            if self.git_client is None:
+                raise RuntimeError(
+                    f"Module '{mod.source}' pins ref={mod.ref!r} which differs from the "
+                    f"snapshot ref {self.source_code_ref!r}, but OtfProvider was constructed without a "
+                    f"git_client to fetch it. Cannot build a correct snapshot."
+                )
+            sha = await self.git_client.fetch_ref(mod.ref)
+            file_paths = await self.git_client.list_files_at_ref(sha, mod.subpath)
+            tf_files = [p for p in file_paths if p.endswith(".tf")]
+            logger.info(
+                f"[tf_parser] including pinned module '{mod.source}' -> {mod.subpath}@{mod.ref} "
+                f"({len(tf_files)} .tf files)"
+            )
+            for repo_path in tf_files:
+                content = await self.git_client.read_file_at_ref(sha, repo_path)
+                display = f"{repo_path}@{mod.ref}"
+                self.tf_string_data += self._FILE_DIVIDER.format(display)
+                self.tf_string_data += content + "\n"
+                queue.extend(self._extract_module_refs(content, posixpath.dirname(repo_path), mod.ref))
 
     async def parse_tf_directory_to_json(self):
         """Parse all Terraform files in a given folder to JSON."""

--- a/server/src/core/tools/git_client.py
+++ b/server/src/core/tools/git_client.py
@@ -1,10 +1,28 @@
 import logging
+import re
 import shutil
 from typing import Any
 
 from core.tools.shell_client import ShellScriptClient
 
 logger = logging.getLogger(__name__)
+
+# Refs and paths are taken from Terraform module sources, which come from
+# user-controlled .tf files. Validating them defensively avoids argument
+# injection against `git fetch`/`git show` (e.g. a ref like
+# "--upload-pack=evil").
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
+_GIT_PATH_RE = re.compile(r"^[A-Za-z0-9_./\-]+$")
+
+
+def _validate_git_ref(ref: str) -> None:
+    if not ref or ref.startswith("-") or ".." in ref.split("/") or not _GIT_REF_RE.match(ref):
+        raise ValueError(f"invalid git ref: {ref!r}")
+
+
+def _validate_git_path(path: str) -> None:
+    if not path or path.startswith("-") or ".." in path.split("/") or not _GIT_PATH_RE.match(path):
+        raise ValueError(f"invalid git path: {path!r}")
 
 
 class GitClient:
@@ -51,6 +69,32 @@ class GitClient:
 
         command_args = f"clone -q --depth 1 --single-branch --branch {branch} {self.git_url} {self.destination_dir}"
         _ = await self._run_git_command(command_args, self.workspace_path)
+
+    async def fetch_ref(self, ref: str) -> str:
+        """Fetch a specific ref into the existing (shallow) clone and return
+        its resolved commit SHA. The clone's working tree is not modified —
+        the commit is reachable via the returned SHA (and via FETCH_HEAD).
+
+        Raises if the ref can't be fetched (missing, no auth, etc.).
+        """
+        _validate_git_ref(ref)
+        self.logger.info(f"Fetching ref {ref} into {self.destination_dir}")
+        _ = await self._run_git_command(["fetch", "--depth", "1", "origin", ref], self.destination_dir)
+        sha = await self._run_git_command(["rev-parse", "FETCH_HEAD"], self.destination_dir)
+        return sha.strip()
+
+    async def list_files_at_ref(self, ref: str, subpath: str) -> list[str]:
+        """List file paths at <ref>:<subpath>, returned as paths from repo root."""
+        _validate_git_ref(ref)
+        _validate_git_path(subpath)
+        out = await self._run_git_command(["ls-tree", "-r", "--name-only", ref, "--", subpath], self.destination_dir)
+        return [line for line in out.splitlines() if line.strip()]
+
+    async def read_file_at_ref(self, ref: str, path: str) -> str:
+        """Return the content of a single file at <ref>:<path>."""
+        _validate_git_ref(ref)
+        _validate_git_path(path)
+        return await self._run_git_command(["show", f"{ref}:{path}"], self.destination_dir)
 
     async def delete_workspace(self):
         shutil.rmtree(self.destination_dir, ignore_errors=True)

--- a/server/tests/application/tools/fixtures/tf_local_modules/modules/network/main.tf
+++ b/server/tests/application/tools/fixtures/tf_local_modules/modules/network/main.tf
@@ -1,0 +1,12 @@
+variable "cidr" {
+  type = string
+}
+
+module "subnet" {
+  source = "../subnet"
+  az     = "eu-west-1a"
+}
+
+resource "vpc" "this" {
+  cidr_block = var.cidr
+}

--- a/server/tests/application/tools/fixtures/tf_local_modules/modules/subnet/main.tf
+++ b/server/tests/application/tools/fixtures/tf_local_modules/modules/subnet/main.tf
@@ -1,0 +1,7 @@
+variable "az" {
+  type = string
+}
+
+resource "subnet" "this" {
+  availability_zone = var.az
+}

--- a/server/tests/application/tools/fixtures/tf_local_modules/stacks/prod/main.tf
+++ b/server/tests/application/tools/fixtures/tf_local_modules/stacks/prod/main.tf
@@ -1,0 +1,18 @@
+module "network" {
+  source = "../../modules/network"
+  cidr   = "10.0.0.0/16"
+}
+
+module "naming" {
+  source = "./naming"
+  prefix = "prod"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.0.0"
+}
+
+resource "iam_user" "prod" {
+  name = "prod-user"
+}

--- a/server/tests/application/tools/fixtures/tf_local_modules/stacks/prod/naming/main.tf
+++ b/server/tests/application/tools/fixtures/tf_local_modules/stacks/prod/naming/main.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  type = string
+}
+
+output "name" {
+  value = "${var.prefix}-resource"
+}

--- a/server/tests/application/tools/test_tf_parser.py
+++ b/server/tests/application/tools/test_tf_parser.py
@@ -121,6 +121,54 @@ class TestTraverseDirectories:
         assert len(files) == 7
 
 
+class TestLocalModuleResolution:
+    REPO_ROOT = "tests/application/tools/fixtures/tf_local_modules"
+    WORKSPACE = f"{REPO_ROOT}/stacks/prod"
+
+    @pytest.mark.asyncio
+    async def test_local_modules_included_in_snapshot(self):
+        tf = OtfProvider(self.WORKSPACE, repo_root=self.REPO_ROOT, follow_modules=True)
+        await tf.read_files_to_string()
+        snapshot = tf.tf_string_data
+
+        # The configured folder's own file is present.
+        assert "prod-user" in snapshot
+        # Sibling local module ("../../modules/network") is pulled in.
+        assert "var.cidr" in snapshot
+        # Nested local module reached transitively ("../subnet" from network).
+        assert "availability_zone" in snapshot
+        # Local module relative to the folder ("./naming") is pulled in.
+        assert "${var.prefix}-resource" in snapshot
+
+    @pytest.mark.asyncio
+    async def test_external_module_not_fetched(self):
+        tf = OtfProvider(self.WORKSPACE, repo_root=self.REPO_ROOT, follow_modules=True)
+        await tf.read_files_to_string()
+        # The registry module "terraform-aws-modules/eks/aws" must not be resolved
+        # as a local path; only its reference inside main.tf appears.
+        assert tf.tf_string_data.count("terraform-aws-modules/eks/aws") == 1
+
+    @pytest.mark.asyncio
+    async def test_files_are_not_duplicated(self):
+        tf = OtfProvider(self.WORKSPACE, repo_root=self.REPO_ROOT, follow_modules=True)
+        await tf.read_files_to_string()
+        # Each discovered file contributes exactly one FILE divider.
+        assert tf.tf_string_data.count("FILE: ") == 4
+
+    def test_extract_module_refs(self):
+        tf = OtfProvider(self.WORKSPACE, repo_root=self.REPO_ROOT)
+        tf_data = """
+        module "local" { source = "../modules/network" }
+        module "dot"   { source = "./naming" }
+        module "registry" { source = "terraform-aws-modules/eks/aws" }
+        module "git" { source = "git::https://example.com/vpc.git" }
+        """
+        refs = tf._extract_module_refs(tf_data, "stacks/prod", None)
+        # Only the two local-path references resolve inside this repo; the
+        # registry and the external git source are dropped.
+        assert sorted(ref.source for ref in refs) == ["../modules/network", "./naming"]
+
+
 class AsyncMockFile:
     def __init__(self):
         self.write = AsyncMock()

--- a/ui/frontend-lib/src/common/components/viewers/HclCodeViewer.tsx
+++ b/ui/frontend-lib/src/common/components/viewers/HclCodeViewer.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
 
+import { useColorScheme } from "@mui/material";
 import CodeMirror from "@uiw/react-codemirror";
 import { hcl } from "codemirror-lang-hcl";
 
@@ -13,12 +14,18 @@ const hclExtensions = [hcl()];
 export const HclCodeViewer: FC<HclCodeViewerProps> = ({
   value,
   readOnly = true,
-}) => (
-  <CodeMirror
-    value={value}
-    extensions={hclExtensions}
-    readOnly={readOnly}
-    editable={!readOnly}
-    basicSetup={{ foldGutter: true, lineNumbers: true }}
-  />
-);
+}) => {
+  const { mode, systemMode } = useColorScheme();
+  const resolvedMode = mode === "system" ? systemMode : mode;
+
+  return (
+    <CodeMirror
+      value={value}
+      theme={resolvedMode === "dark" ? "dark" : "light"}
+      extensions={hclExtensions}
+      readOnly={readOnly}
+      editable={!readOnly}
+      basicSetup={{ foldGutter: true, lineNumbers: true }}
+    />
+  );
+};

--- a/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
+++ b/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
@@ -28,27 +28,6 @@ interface TreeNode {
 }
 
 const FILE_DIVIDER_PATTERN = /^#\s*-{2,}\s*FILE:\s*(.+?)\s*-{2,}\s*$/;
-
-/** Deterministic hue per ref string so each tag is visually distinct but
- * stable across renders. */
-function refColor(ref: string): { bg: string; fg: string; border: string } {
-  // FNV-1a 32-bit — good avalanche so eks-3.0.2 and eks-3.1.2 hash very
-  // differently despite sharing most characters.
-  let h = 0x811c9dc5;
-  for (let i = 0; i < ref.length; i++) {
-    h ^= ref.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  const u = h >>> 0;
-  const hue = u % 360;
-  const sat = 55 + ((u >>> 9) % 40); // 55–94
-  const light = 25 + ((u >>> 17) % 25); // 25–49
-  return {
-    bg: `hsl(${hue}, ${sat}%, ${light}%)`,
-    fg: `hsl(${hue}, ${Math.min(95, sat + 20)}%, 92%)`,
-    border: `hsl(${hue}, ${sat}%, ${Math.min(60, light + 15)}%)`,
-  };
-}
 const REF_PATTERN = /@([^/]+)$/;
 
 const displayRef = (ref: string) => (ref === "HEAD" ? "Latest" : ref);
@@ -162,28 +141,20 @@ function renderTreeItems(nodes: TreeNode[]) {
             >
               {isFolder ? node.name : node.name.replace(/@[^/]+$/, "")}
             </Typography>
-            {!isFolder &&
-              node.file?.ref &&
-              (() => {
-                const c = refColor(node.file.ref);
-                return (
-                  <Chip
-                    label={displayRef(node.file.ref)}
-                    size="small"
-                    variant="outlined"
-                    sx={{
-                      ml: "auto",
-                      height: 18,
-                      fontSize: 11,
-                      fontFamily: "'Roboto Mono', monospace",
-                      bgcolor: c.bg,
-                      color: c.fg,
-                      borderColor: c.border,
-                      "& .MuiChip-label": { px: 0.75 },
-                    }}
-                  />
-                );
-              })()}
+            {!isFolder && node.file?.ref && (
+              <Chip
+                label={displayRef(node.file.ref)}
+                size="small"
+                variant="outlined"
+                sx={{
+                  ml: "auto",
+                  height: 18,
+                  fontSize: 11,
+                  fontFamily: "'Roboto Mono', monospace",
+                  "& .MuiChip-label": { px: 0.75 },
+                }}
+              />
+            )}
           </Box>
         }
       >
@@ -303,23 +274,14 @@ export const CodeSnapshotTab: FC<CodeSnapshotTabProps> = ({
               >
                 {selectedFile.filename.replace(/@[^/]+$/, "")}
               </Typography>
-              {selectedFile.ref &&
-                (() => {
-                  const c = refColor(selectedFile.ref);
-                  return (
-                    <Chip
-                      label={displayRef(selectedFile.ref)}
-                      size="small"
-                      variant="outlined"
-                      sx={{
-                        fontFamily: "'Roboto Mono', monospace",
-                        bgcolor: c.bg,
-                        color: c.fg,
-                        borderColor: c.border,
-                      }}
-                    />
-                  );
-                })()}
+              {selectedFile.ref && (
+                <Chip
+                  label={displayRef(selectedFile.ref)}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontFamily: "'Roboto Mono', monospace" }}
+                />
+              )}
             </Box>
             <Box sx={{ flex: 1, overflow: "auto" }}>
               {renderFileViewer(selectedFile, colorMode)}

--- a/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
+++ b/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
@@ -1,29 +1,60 @@
-import { FC, useMemo } from "react";
+import { FC, useMemo, useState } from "react";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Typography,
-} from "@mui/material";
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
+import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
+import { Box, Chip, Typography, useColorScheme } from "@mui/material";
+import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
+import { TreeItem } from "@mui/x-tree-view/TreeItem";
 import CodeMirror from "@uiw/react-codemirror";
 
 import { HclCodeViewer } from "../../common/components/viewers/HclCodeViewer";
 
 interface CodeSnapshotTabProps {
   codeSnapshot: string | null | undefined;
+  defaultRef?: string;
 }
 
 interface ParsedFile {
   filename: string;
   content: string;
+  ref?: string;
+}
+
+interface TreeNode {
+  name: string;
+  path: string;
+  children: TreeNode[];
+  file?: ParsedFile;
 }
 
 const FILE_DIVIDER_PATTERN = /^#\s*-{2,}\s*FILE:\s*(.+?)\s*-{2,}\s*$/;
 
-function parseCodeSnapshot(snapshot: string | null | undefined): ParsedFile[] {
+/** Deterministic hue per ref string so each tag is visually distinct but
+ * stable across renders. */
+function refColor(ref: string): { bg: string; fg: string; border: string } {
+  // FNV-1a 32-bit — good avalanche so eks-3.0.2 and eks-3.1.2 hash very
+  // differently despite sharing most characters.
+  let h = 0x811c9dc5;
+  for (let i = 0; i < ref.length; i++) {
+    h ^= ref.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  const u = h >>> 0;
+  const hue = u % 360;
+  const sat = 55 + ((u >>> 9) % 40); // 55–94
+  const light = 25 + ((u >>> 17) % 25); // 25–49
+  return {
+    bg: `hsl(${hue}, ${sat}%, ${light}%)`,
+    fg: `hsl(${hue}, ${Math.min(95, sat + 20)}%, 92%)`,
+    border: `hsl(${hue}, ${sat}%, ${Math.min(60, light + 15)}%)`,
+  };
+}
+const REF_PATTERN = /@([^/]+)$/;
+
+function parseCodeSnapshot(
+  snapshot: string | null | undefined,
+  defaultRef?: string,
+): ParsedFile[] {
   if (!snapshot) return [];
   const lines = snapshot.split("\n");
   const files: ParsedFile[] = [];
@@ -36,7 +67,13 @@ function parseCodeSnapshot(snapshot: string | null | undefined): ParsedFile[] {
         currentFile.content = currentFile.content.trimEnd();
         files.push(currentFile);
       }
-      currentFile = { filename: match[1].trim(), content: "" };
+      const filename = match[1].trim();
+      const refMatch = filename.match(REF_PATTERN);
+      currentFile = {
+        filename,
+        content: "",
+        ref: refMatch ? refMatch[1] : defaultRef,
+      };
     } else if (currentFile) {
       currentFile.content += line + "\n";
     }
@@ -50,7 +87,111 @@ function parseCodeSnapshot(snapshot: string | null | undefined): ParsedFile[] {
   return files;
 }
 
-function renderFileViewer(file: ParsedFile) {
+/** Build a nested folder/file tree from flat, "/"-separated file paths. */
+function buildTree(files: ParsedFile[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", children: [] };
+
+  for (const file of files) {
+    const parts = file.filename.split("/").filter(Boolean);
+    let node = root;
+    let acc = "";
+
+    parts.forEach((part, idx) => {
+      acc = acc ? `${acc}/${part}` : part;
+      let child = node.children.find((c) => c.name === part);
+      if (!child) {
+        child = { name: part, path: acc, children: [] };
+        node.children.push(child);
+      }
+      node = child;
+      if (idx === parts.length - 1) node.file = file;
+    });
+  }
+
+  return root;
+}
+
+/** Folders first, then files; alphabetical within each group. */
+function sortNodes(nodes: TreeNode[]): TreeNode[] {
+  return [...nodes].sort((a, b) => {
+    const aIsFolder = a.children.length > 0;
+    const bIsFolder = b.children.length > 0;
+    if (aIsFolder !== bIsFolder) return aIsFolder ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function collectFolderPaths(node: TreeNode, acc: string[] = []): string[] {
+  for (const child of node.children) {
+    if (child.children.length > 0) {
+      acc.push(child.path);
+      collectFolderPaths(child, acc);
+    }
+  }
+  return acc;
+}
+
+function renderTreeItems(nodes: TreeNode[]) {
+  return sortNodes(nodes).map((node) => {
+    const isFolder = node.children.length > 0;
+    return (
+      <TreeItem
+        key={node.path}
+        itemId={node.path}
+        label={
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              py: 0.25,
+              width: "100%",
+              pr: 1,
+            }}
+          >
+            {isFolder ? (
+              <FolderOutlinedIcon fontSize="small" color="action" />
+            ) : (
+              <DescriptionOutlinedIcon fontSize="small" color="action" />
+            )}
+            <Typography
+              variant="body2"
+              sx={{ fontFamily: "'Roboto Mono', monospace", fontSize: 13 }}
+            >
+              {isFolder ? node.name : node.name.replace(/@[^/]+$/, "")}
+            </Typography>
+            {!isFolder &&
+              node.file?.ref &&
+              (() => {
+                const c = refColor(node.file.ref);
+                return (
+                  <Chip
+                    label={node.file.ref}
+                    size="small"
+                    variant="outlined"
+                    sx={{
+                      ml: "auto",
+                      height: 18,
+                      fontSize: 11,
+                      fontFamily: "'Roboto Mono', monospace",
+                      bgcolor: c.bg,
+                      color: c.fg,
+                      borderColor: c.border,
+                      "& .MuiChip-label": { px: 0.75 },
+                    }}
+                  />
+                );
+              })()}
+          </Box>
+        }
+      >
+        {isFolder ? renderTreeItems(node.children) : null}
+      </TreeItem>
+    );
+  });
+}
+
+function renderFileViewer(file: ParsedFile, colorMode: "light" | "dark") {
   if (file.filename.endsWith(".tf")) {
     return <HclCodeViewer value={file.content} />;
   }
@@ -58,6 +199,7 @@ function renderFileViewer(file: ParsedFile) {
   return (
     <CodeMirror
       value={file.content}
+      theme={colorMode}
       readOnly
       editable={false}
       basicSetup={{ foldGutter: true, lineNumbers: true }}
@@ -65,8 +207,32 @@ function renderFileViewer(file: ParsedFile) {
   );
 }
 
-export const CodeSnapshotTab: FC<CodeSnapshotTabProps> = ({ codeSnapshot }) => {
-  const files = useMemo(() => parseCodeSnapshot(codeSnapshot), [codeSnapshot]);
+export const CodeSnapshotTab: FC<CodeSnapshotTabProps> = ({
+  codeSnapshot,
+  defaultRef,
+}) => {
+  const { mode, systemMode } = useColorScheme();
+  const resolvedMode = mode === "system" ? systemMode : mode;
+  const colorMode: "light" | "dark" =
+    resolvedMode === "dark" ? "dark" : "light";
+
+  const files = useMemo(
+    () => parseCodeSnapshot(codeSnapshot, defaultRef),
+    [codeSnapshot, defaultRef],
+  );
+  const tree = useMemo(() => buildTree(files), [files]);
+
+  const filesByPath = useMemo(() => {
+    const map = new Map<string, ParsedFile>();
+    for (const file of files) map.set(file.filename, file);
+    return map;
+  }, [files]);
+
+  const [selected, setSelected] = useState<string | null>(
+    files[0]?.filename ?? null,
+  );
+
+  const defaultExpanded = useMemo(() => collectFolderPaths(tree), [tree]);
 
   if (files.length === 0) {
     return (
@@ -76,23 +242,93 @@ export const CodeSnapshotTab: FC<CodeSnapshotTabProps> = ({ codeSnapshot }) => {
     );
   }
 
+  const selectedFile = selected ? filesByPath.get(selected) : undefined;
+
   return (
-    <Box sx={{ pt: 0.5, display: "flex", flexDirection: "column", gap: 1 }}>
-      {files.map((file) => (
-        <Accordion key={file.filename} defaultExpanded disableGutters>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography
-              variant="subtitle2"
-              sx={{ fontFamily: "'Roboto Mono', monospace" }}
+    <Box
+      sx={{
+        display: "flex",
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        overflow: "hidden",
+        minHeight: 400,
+      }}
+    >
+      <Box
+        sx={{
+          width: 300,
+          flexShrink: 0,
+          borderRight: 1,
+          borderColor: "divider",
+          bgcolor: "background.default",
+          overflow: "auto",
+          py: 0.5,
+        }}
+      >
+        <SimpleTreeView
+          defaultExpandedItems={defaultExpanded}
+          selectedItems={selected}
+          onSelectedItemsChange={(_e, itemId) => {
+            // Only switch the editor when a file (leaf) is selected.
+            if (itemId && filesByPath.has(itemId)) setSelected(itemId);
+          }}
+        >
+          {renderTreeItems(tree.children)}
+        </SimpleTreeView>
+      </Box>
+
+      <Box
+        sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}
+      >
+        {selectedFile ? (
+          <>
+            <Box
+              sx={{
+                px: 1.5,
+                py: 1,
+                borderBottom: 1,
+                borderColor: "divider",
+                bgcolor: "background.default",
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+              }}
             >
-              {file.filename}
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails sx={{ p: 0 }}>
-            {renderFileViewer(file)}
-          </AccordionDetails>
-        </Accordion>
-      ))}
+              <Typography
+                variant="subtitle2"
+                sx={{ fontFamily: "'Roboto Mono', monospace" }}
+              >
+                {selectedFile.filename.replace(/@[^/]+$/, "")}
+              </Typography>
+              {selectedFile.ref &&
+                (() => {
+                  const c = refColor(selectedFile.ref);
+                  return (
+                    <Chip
+                      label={selectedFile.ref}
+                      size="small"
+                      variant="outlined"
+                      sx={{
+                        fontFamily: "'Roboto Mono', monospace",
+                        bgcolor: c.bg,
+                        color: c.fg,
+                        borderColor: c.border,
+                      }}
+                    />
+                  );
+                })()}
+            </Box>
+            <Box sx={{ flex: 1, overflow: "auto" }}>
+              {renderFileViewer(selectedFile, colorMode)}
+            </Box>
+          </>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+            Select a file to view its contents.
+          </Typography>
+        )}
+      </Box>
     </Box>
   );
 };

--- a/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
+++ b/ui/frontend-lib/src/source_code_versions/components/CodeSnapshotTab.tsx
@@ -51,6 +51,8 @@ function refColor(ref: string): { bg: string; fg: string; border: string } {
 }
 const REF_PATTERN = /@([^/]+)$/;
 
+const displayRef = (ref: string) => (ref === "HEAD" ? "Latest" : ref);
+
 function parseCodeSnapshot(
   snapshot: string | null | undefined,
   defaultRef?: string,
@@ -166,7 +168,7 @@ function renderTreeItems(nodes: TreeNode[]) {
                 const c = refColor(node.file.ref);
                 return (
                   <Chip
-                    label={node.file.ref}
+                    label={displayRef(node.file.ref)}
                     size="small"
                     variant="outlined"
                     sx={{
@@ -306,7 +308,7 @@ export const CodeSnapshotTab: FC<CodeSnapshotTabProps> = ({
                   const c = refColor(selectedFile.ref);
                   return (
                     <Chip
-                      label={selectedFile.ref}
+                      label={displayRef(selectedFile.ref)}
                       size="small"
                       variant="outlined"
                       sx={{

--- a/ui/frontend-lib/src/source_code_versions/components/SourceCodeVersionContent.tsx
+++ b/ui/frontend-lib/src/source_code_versions/components/SourceCodeVersionContent.tsx
@@ -48,7 +48,13 @@ export const SourceCodeVersionContent = () => {
     {
       label: "Code",
       content: (
-        <CodeSnapshotTab codeSnapshot={source_code_version.code_snapshot} />
+        <CodeSnapshotTab
+          codeSnapshot={source_code_version.code_snapshot}
+          defaultRef={
+            source_code_version.source_code_version ||
+            source_code_version.source_code_branch
+          }
+        />
       ),
     },
     {


### PR DESCRIPTION
This PR:

- Fixes the dark mode for HCL code viewer
- Updates the `Code` tab for SCVs to have a better UX, all files are listed on the left and the user can choose which file he wants to view, folders are collapsible:

<img width="1528" height="623" alt="image" src="https://github.com/user-attachments/assets/d72834ba-5aa4-4912-a321-3a4c12c6bbdd" />

- Updates the terraform parser to pull in all code that is related to the source code version with the following cases covered:
  - `../` or `./` local refs - these will use the same working directory as the snapshot for the main module
  - ` git::ssh://<git-url>//modules/kms` - this will pull the latest version of the referenced module on every synchronization
  - `git::ssh://<git-url>//modules/kms?ref=<tag>` - this will pull the exact version referenced in the tag
  - No external dependencies are pulled, there is a strict check that will only fetch local refs and git refs that live in the same repository.
- The UI also shows next to each file which tag they use, in the following example the main module (`/aws/eks/`) references `/modules/eks?ref=eks-3.2.5`, which in turn references `/modules/rds?ref=rds-1.0.2` and the rds references the latest `/modules/kms` module. Local refs will have the same tag applied as the SCV.
- Inputs and Outputs are only computed for the main folder.

<img width="1126" height="854" alt="image" src="https://github.com/user-attachments/assets/2fb32760-21b0-43e2-8354-252611d59c83" />


Closes #255   