### PR TITLE
align storage permissions for ui with backend behavior

### DIFF
--- a/ui/frontend-lib/src/executors/components/AdvancedSettings.tsx
+++ b/ui/frontend-lib/src/executors/components/AdvancedSettings.tsx
@@ -34,10 +34,10 @@ const INTEGRATION_STORAGE_WARNING =
 
 export const AdvancedSettings = ({ executor }: AdvancedSettingsProps) => {
   const { ikApi } = useConfig();
-  const { refreshEntity } = useEntityProvider();
+  const { refreshEntity, userEntityPermissions } = useEntityProvider();
   const { checkActionPermission } = usePermissionProvider();
   const canEdit = checkActionPermission("api:executor", "write");
-  const canEditStorage = checkActionPermission("api:storage", "admin");
+  const canEditStorage = userEntityPermissions.includes("admin");
 
   const saveField = useCallback(
     async (input: ExecutorUpdateFieldInput) => {

--- a/ui/frontend-lib/src/resources/components/TemplateConfiguration.tsx
+++ b/ui/frontend-lib/src/resources/components/TemplateConfiguration.tsx
@@ -164,10 +164,11 @@ export const TemplateConfiguration = ({
   resource,
 }: TemplateConfigurationProps) => {
   const { ikApi } = useConfig();
-  const { refreshEntity, hasPendingChange } = useEntityProvider();
+  const { refreshEntity, hasPendingChange, userEntityPermissions } =
+    useEntityProvider();
   const { checkActionPermission } = usePermissionProvider();
   const canEdit = checkActionPermission("api:resource", "write");
-  const canEditStorage = checkActionPermission("api:storage", "admin");
+  const canEditStorage = userEntityPermissions.includes("admin");
   const sourceCodeVersionLifecycleState =
     resource.sourceCodeVersion?.lifecycleState?.toLowerCase();
   const showSourceCodeVersionLifecycleState =


### PR DESCRIPTION
Backend already authorizes this operation based on entity permissions, not api:storage admin so technically no increased privileges, just UI change to let resource admins update storage fields via UI.